### PR TITLE
cache: expose Redis maxmemory-policy for eviction (LRU/LFU/etc)

### DIFF
--- a/cache/engine/client/client.go
+++ b/cache/engine/client/client.go
@@ -30,6 +30,20 @@ import (
 
 var ctx = context.Background()
 
+// validEvictionPolicies - Allowed values for Redis' maxmemory-policy. Kept as
+// an allowlist since the value may come from an env var (trust boundary)
+// before being sent verbatim to Redis via CONFIG SET.
+var validEvictionPolicies = map[string]bool{
+	"noeviction":      true,
+	"allkeys-lru":     true,
+	"allkeys-lfu":     true,
+	"volatile-lru":    true,
+	"volatile-lfu":    true,
+	"allkeys-random":  true,
+	"volatile-random": true,
+	"volatile-ttl":    true,
+}
+
 // RedisClient - Redis Client structure.
 type RedisClient struct {
 	Client  goredislib.UniversalClient
@@ -58,7 +72,27 @@ func Connect(connName string, config config.Cache, logger *log.Logger) *RedisCli
 		logger:  logger,
 	}
 
+	applyEvictionPolicy(rdb, config.EvictionPolicy)
+
 	return rdb
+}
+
+// applyEvictionPolicy - Sets Redis' own maxmemory-policy (LRU/LFU/etc) on
+// connect. Redis already implements eviction natively, so there is no
+// reimplementation here, just exposing the existing knob via config.
+func applyEvictionPolicy(rdb *RedisClient, policy string) {
+	if policy == "" {
+		return
+	}
+
+	if !validEvictionPolicies[policy] {
+		rdb.logger.Errorf("Invalid REDIS_EVICTION_POLICY %q, skipping", policy)
+		return
+	}
+
+	if err := rdb.Client.ConfigSet(ctx, "maxmemory-policy", policy).Err(); err != nil {
+		rdb.logger.Errorf("Failed to set maxmemory-policy=%s: %s", policy, err)
+	}
 }
 
 // Close - Closes the connection.

--- a/cache/engine/client/eviction_policy_test.go
+++ b/cache/engine/client/eviction_policy_test.go
@@ -1,0 +1,50 @@
+package client
+
+//                                                                         __
+// .-----.-----.______.-----.----.-----.--.--.--.--.______.----.---.-.----|  |--.-----.
+// |  _  |  _  |______|  _  |   _|  _  |_   _|  |  |______|  __|  _  |  __|     |  -__|
+// |___  |_____|      |   __|__| |_____|__.__|___  |      |____|___._|____|__|__|_____|
+// |_____|            |__|                   |_____|
+//
+// Copyright (c) 2023 Fabio Cicerchia. https://fabiocicerchia.it. MIT License
+// Repo: https://github.com/fabiocicerchia/go-proxy-cache
+
+import (
+	"testing"
+
+	log "github.com/sirupsen/logrus"
+	"github.com/sirupsen/logrus/hooks/test"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestApplyEvictionPolicyInvalidIsRejected(t *testing.T) {
+	logger, hook := test.NewNullLogger()
+
+	rdb := &RedisClient{Name: "testing", logger: logger}
+
+	applyEvictionPolicy(rdb, "not-a-real-policy")
+
+	assert.Equal(t, log.ErrorLevel, hook.LastEntry().Level)
+	assert.Contains(t, hook.LastEntry().Message, "Invalid REDIS_EVICTION_POLICY")
+}
+
+func TestApplyEvictionPolicyEmptyIsNoop(t *testing.T) {
+	logger, hook := test.NewNullLogger()
+
+	rdb := &RedisClient{Name: "testing", logger: logger}
+
+	applyEvictionPolicy(rdb, "")
+
+	assert.Nil(t, hook.LastEntry())
+}
+
+func TestValidEvictionPoliciesMatchRedisMaxmemoryPolicy(t *testing.T) {
+	for _, policy := range []string{
+		"noeviction", "allkeys-lru", "allkeys-lfu", "volatile-lru",
+		"volatile-lfu", "allkeys-random", "volatile-random", "volatile-ttl",
+	} {
+		assert.True(t, validEvictionPolicies[policy], "expected %s to be valid", policy)
+	}
+
+	assert.False(t, validEvictionPolicies["bogus"])
+}

--- a/config/model.go
+++ b/config/model.go
@@ -160,6 +160,11 @@ type Cache struct {
 	TTL             int      `yaml:"ttl" envconfig:"DEFAULT_TTL"`
 	AllowedStatuses []int    `yaml:"allowed_statuses" envconfig:"CACHE_ALLOWED_STATUSES" split_words:"true"`
 	AllowedMethods  []string `yaml:"allowed_methods" envconfig:"CACHE_ALLOWED_METHODS" split_words:"true"`
+	// EvictionPolicy - Redis maxmemory-policy applied on connect. One of:
+	// noeviction, allkeys-lru, allkeys-lfu, volatile-lru, volatile-lfu,
+	// allkeys-random, volatile-random, volatile-ttl. Empty leaves Redis's own
+	// default (noeviction) untouched.
+	EvictionPolicy string `yaml:"eviction_policy" envconfig:"REDIS_EVICTION_POLICY"`
 }
 
 // Log - Defines the config for the logs.

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -23,6 +23,7 @@
 - `LB_ENDPOINT_LIST`
 - `REDIRECT_STATUS_CODE` = `301`
 - `REDIS_DB`
+- `REDIS_EVICTION_POLICY` - Redis `maxmemory-policy` to apply on connect (e.g. `allkeys-lru`, `allkeys-lfu`). Empty leaves Redis's own default.
 - `REDIS_HOSTS`
 - `REDIS_PASSWORD`
 - `SENTRY_DSN`


### PR DESCRIPTION
## Summary
Redis already implements key eviction natively via `maxmemory-policy` (noeviction, allkeys-lru, allkeys-lfu, volatile-lru, volatile-lfu, allkeys-random, volatile-random, volatile-ttl). Rather than reimplementing LRU/LFU logic in application code, this exposes that existing knob through config:

- `REDIS_EVICTION_POLICY` / `eviction_policy` (default empty = Redis's own default, `noeviction`, untouched)
- Applied via `CONFIG SET maxmemory-policy <value>` right after connecting
- Value is validated against the known Redis policy set before being sent (it may come from an env var, so it's a trust boundary)

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./cache/...` (new unit tests for valid/invalid/empty policy handling)

Closes #21

Draft PR — minimal implementation, opening for review/feedback.