### PR TITLE
fix(cache): bypass cache for Range requests and partial content

### DIFF
--- a/cache/cache.go
+++ b/cache/cache.go
@@ -84,6 +84,22 @@ func (c Object) IsMethodAllowed() bool {
 	return slice.ContainsString(c.AllowedMethods, c.CurrentURIObject.Method)
 }
 
+// HasRangeRequest - Checks if the incoming request asked for a byte range.
+// Range requests must always bypass the cache: this cache stores/serves whole
+// bodies, so returning a full cached body for a ranged request would be a
+// wrong response (wrong status code and bytes) to the client.
+func (u URIObj) HasRangeRequest() bool {
+	return u.RequestHeaders.Get("Range") != ""
+}
+
+// IsPartialContent - Checks if the response is a partial content response
+// (206, or carrying Content-Range). Such responses must never be stored as if
+// they were the full resource, or later non-range requests would be served
+// truncated bytes.
+func (u URIObj) IsPartialContent() bool {
+	return u.StatusCode == http.StatusPartialContent || u.ResponseHeaders.Get("Content-Range") != ""
+}
+
 func getRandomSoftExpirationTTL() time.Duration {
 	// Pick a random value in the range [Min, Max) so the soft expiration jitter
 	// respects its lower bound. The previous formula (Max - Min + Min) collapsed
@@ -148,14 +164,17 @@ func (c Object) handleMetadata(ctx context.Context, domainID string, targetURL u
 
 // StoreFullPage - Stores the whole page response in cache.
 func (c Object) StoreFullPage(ctx context.Context, expiration time.Duration) (bool, error) {
-	if !c.IsStatusAllowed() || !c.IsMethodAllowed() || expiration < 1 {
+	if !c.IsStatusAllowed() || !c.IsMethodAllowed() || expiration < 1 ||
+		c.CurrentURIObject.HasRangeRequest() || c.CurrentURIObject.IsPartialContent() {
 		logger.GetGlobal().WithFields(log.Fields{
 			"ReqID": c.ReqID,
 		}).Debugf(
-			"Not allowed to be stored. Status: %v - Method: %v - Expiration: %v",
+			"Not allowed to be stored. Status: %v - Method: %v - Expiration: %v - Range: %v - Partial: %v",
 			c.IsStatusAllowed(),
 			c.IsMethodAllowed(),
 			expiration,
+			c.CurrentURIObject.HasRangeRequest(),
+			c.CurrentURIObject.IsPartialContent(),
 		)
 
 		return false, nil
@@ -195,6 +214,10 @@ func (c Object) StoreFullPage(ctx context.Context, expiration time.Duration) (bo
 
 // RetrieveFullPage - Retrieves the whole page response from cache.
 func (c *Object) RetrieveFullPage() error {
+	if c.CurrentURIObject.HasRangeRequest() {
+		return ErrEmptyValue
+	}
+
 	obj := &URIObj{}
 
 	meta, err := FetchMetadata(c.DomainID, c.CurrentURIObject.Method, c.CurrentURIObject.URL)

--- a/cache/cache_unit_test.go
+++ b/cache/cache_unit_test.go
@@ -1,0 +1,100 @@
+//go:build all || unit
+// +build all unit
+
+package cache_test
+
+//                                                                         __
+// .-----.-----.______.-----.----.-----.--.--.--.--.______.----.---.-.----|  |--.-----.
+// |  _  |  _  |______|  _  |   _|  _  |_   _|  |  |______|  __|  _  |  __|     |  -__|
+// |___  |_____|      |   __|__| |_____|__.__|___  |      |____|___._|____|__|__|_____|
+// |_____|            |__|                   |_____|
+//
+// Copyright (c) 2023 Fabio Cicerchia. https://fabiocicerchia.it. MIT License
+// Repo: https://github.com/fabiocicerchia/go-proxy-cache
+
+import (
+	"context"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/fabiocicerchia/go-proxy-cache/cache"
+)
+
+func TestHasRangeRequest(t *testing.T) {
+	withRange := cache.URIObj{RequestHeaders: http.Header{"Range": []string{"bytes=0-99"}}}
+	assert.True(t, withRange.HasRangeRequest())
+
+	withoutRange := cache.URIObj{RequestHeaders: http.Header{}}
+	assert.False(t, withoutRange.HasRangeRequest())
+}
+
+func TestIsPartialContent(t *testing.T) {
+	statusPartial := cache.URIObj{StatusCode: http.StatusPartialContent, ResponseHeaders: http.Header{}}
+	assert.True(t, statusPartial.IsPartialContent())
+
+	contentRange := cache.URIObj{StatusCode: http.StatusOK, ResponseHeaders: http.Header{"Content-Range": []string{"bytes 0-99/200"}}}
+	assert.True(t, contentRange.IsPartialContent())
+
+	full := cache.URIObj{StatusCode: http.StatusOK, ResponseHeaders: http.Header{}}
+	assert.False(t, full.IsPartialContent())
+}
+
+func TestStoreFullPageBypassesCacheForRangeRequest(t *testing.T) {
+	obj := cache.Object{
+		AllowedStatuses: []int{http.StatusOK},
+		AllowedMethods:  []string{http.MethodGet},
+		CurrentURIObject: cache.URIObj{
+			Method:          http.MethodGet,
+			StatusCode:      http.StatusOK,
+			RequestHeaders:  http.Header{"Range": []string{"bytes=0-99"}},
+			ResponseHeaders: http.Header{},
+			Content:         [][]byte{[]byte("hello")},
+		},
+	}
+
+	// No Redis connection is configured; if the Range guard didn't short-circuit
+	// before reaching the engine, this would fail with a connection error
+	// instead of the expected "not stored" false/nil.
+	stored, err := obj.StoreFullPage(context.Background(), time.Minute)
+
+	assert.False(t, stored)
+	assert.NoError(t, err)
+}
+
+func TestStoreFullPageBypassesCacheForPartialContentResponse(t *testing.T) {
+	obj := cache.Object{
+		AllowedStatuses: []int{http.StatusOK, http.StatusPartialContent},
+		AllowedMethods:  []string{http.MethodGet},
+		CurrentURIObject: cache.URIObj{
+			Method:          http.MethodGet,
+			StatusCode:      http.StatusPartialContent,
+			RequestHeaders:  http.Header{},
+			ResponseHeaders: http.Header{"Content-Range": []string{"bytes 0-99/200"}},
+			Content:         [][]byte{[]byte("hello")},
+		},
+	}
+
+	stored, err := obj.StoreFullPage(context.Background(), time.Minute)
+
+	assert.False(t, stored)
+	assert.NoError(t, err)
+}
+
+func TestRetrieveFullPageBypassesCacheForRangeRequest(t *testing.T) {
+	obj := cache.Object{
+		CurrentURIObject: cache.URIObj{
+			Method:         http.MethodGet,
+			RequestHeaders: http.Header{"Range": []string{"bytes=0-99"}},
+		},
+	}
+
+	// No Redis connection is configured; if the Range guard didn't short-circuit
+	// before FetchMetadata/engine.GetConn, this would fail with a connection
+	// error instead of the expected ErrEmptyValue (treated as a cache miss).
+	err := obj.RetrieveFullPage()
+
+	assert.ErrorIs(t, err, cache.ErrEmptyValue)
+}


### PR DESCRIPTION
## What
Range requests (`Range` header) previously ignored the cache layer's
correctness rules:

- A client sending `Range: bytes=0-99` could be served the **full** cached
  body with a `200`, instead of the requested range being forwarded
  upstream.
- An upstream `206 Partial Content` response (or any response carrying
  `Content-Range`) could be written into the cache as if it were the whole
  resource, so a later non-range request would incorrectly get back
  truncated bytes.

Fix: `cache.Object` now has `HasRangeRequest()` / `IsPartialContent()`
guards, wired into the existing `StoreFullPage`/`RetrieveFullPage`
eligibility checks. Range requests and partial responses always bypass the
cache (pass through to upstream, never stored, never served from a stale
full-body copy).

## What this does NOT do
Full byte-range caching (storing/serving individual sub-ranges, `If-Range`
validation, multi-range reassembly - as described in
https://github.com/tricksterproxy/trickster/blob/main/docs/range_request.md)
is a large feature and out of scope for this PR. This only fixes the
correctness bug of serving/storing wrong bytes for ranged requests.

Refs #22

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test -tags unit ./cache/... ./server/handler/...`
- [x] Added `cache/cache_unit_test.go` covering the new guards and the
      early-bypass behavior of `StoreFullPage`/`RetrieveFullPage`