### PR TITLE
feat(cache): negative caching for configurable error statuses

### DIFF
--- a/config/model.go
+++ b/config/model.go
@@ -160,6 +160,32 @@ type Cache struct {
 	TTL             int      `yaml:"ttl" envconfig:"DEFAULT_TTL"`
 	AllowedStatuses []int    `yaml:"allowed_statuses" envconfig:"CACHE_ALLOWED_STATUSES" split_words:"true"`
 	AllowedMethods  []string `yaml:"allowed_methods" envconfig:"CACHE_ALLOWED_METHODS" split_words:"true"`
+	// NegativeTTL - Per-status TTL override (in seconds), e.g. {404: 30, 502: 10},
+	// to cache error responses briefly and shield the origin without waiting on
+	// its (often absent/wrong) Cache-Control headers. YAML-only: envconfig has no
+	// clean map[int]int support, unlike the slice fields above.
+	NegativeTTL map[int]int `yaml:"negative_ttl"`
+}
+
+// EffectiveAllowedStatuses - AllowedStatuses plus any status codes that have a
+// NegativeTTL override, so operators don't have to list the same status twice.
+func (c Cache) EffectiveAllowedStatuses() []int {
+	statuses := append([]int{}, c.AllowedStatuses...)
+
+	for status := range c.NegativeTTL {
+		found := false
+		for _, s := range statuses {
+			if s == status {
+				found = true
+				break
+			}
+		}
+		if !found {
+			statuses = append(statuses, status)
+		}
+	}
+
+	return statuses
 }
 
 // Log - Defines the config for the logs.

--- a/config/model_test.go
+++ b/config/model_test.go
@@ -1,0 +1,49 @@
+//go:build all || unit
+// +build all unit
+
+package config_test
+
+//                                                                         __
+// .-----.-----.______.-----.----.-----.--.--.--.--.______.----.---.-.----|  |--.-----.
+// |  _  |  _  |______|  _  |   _|  _  |_   _|  |  |______|  __|  _  |  __|     |  -__|
+// |___  |_____|      |   __|__| |_____|__.__|___  |      |____|___._|____|__|__|_____|
+// |_____|            |__|                   |_____|
+//
+// Copyright (c) 2023 Fabio Cicerchia. https://fabiocicerchia.it. MIT License
+// Repo: https://github.com/fabiocicerchia/go-proxy-cache
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/fabiocicerchia/go-proxy-cache/config"
+)
+
+// --- EffectiveAllowedStatuses
+
+func TestEffectiveAllowedStatusesWithoutNegativeTTL(t *testing.T) {
+	cache := config.Cache{
+		AllowedStatuses: []int{200, 301},
+	}
+
+	assert.ElementsMatch(t, []int{200, 301}, cache.EffectiveAllowedStatuses())
+}
+
+func TestEffectiveAllowedStatusesMergesNegativeTTLStatuses(t *testing.T) {
+	cache := config.Cache{
+		AllowedStatuses: []int{200},
+		NegativeTTL:     map[int]int{404: 30, 502: 10},
+	}
+
+	assert.ElementsMatch(t, []int{200, 404, 502}, cache.EffectiveAllowedStatuses())
+}
+
+func TestEffectiveAllowedStatusesDoesNotDuplicate(t *testing.T) {
+	cache := config.Cache{
+		AllowedStatuses: []int{200, 404},
+		NegativeTTL:     map[int]int{404: 30},
+	}
+
+	assert.ElementsMatch(t, []int{200, 404}, cache.EffectiveAllowedStatuses())
+}

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -285,6 +285,15 @@ cache:
   allowed_methods:
     - HEAD
     - GET
+  # --- NEGATIVE CACHING
+  # Per-status TTL override (seconds) so error responses (404, 502, ...) get
+  # cached briefly and shield the origin, instead of inheriting origin cache
+  # headers (which error pages rarely set sanely). The status is implicitly
+  # added to allowed_statuses, no need to list it there too.
+  # Default: none
+  negative_ttl:
+    404: 30
+    502: 10
 
 # --- CIRCUIT BREAKER
 # WARNING: INTERNAL SERVER BEHAVIOUR

--- a/server/handler/utils.go
+++ b/server/handler/utils.go
@@ -50,7 +50,7 @@ func ConvertToRequestCallDTO(rc RequestCall) storage.RequestCallDTO {
 		Request:  rc.Request,
 		CacheObject: cache.Object{
 			ReqID:           rc.ReqID,
-			AllowedStatuses: rc.DomainConfig.Cache.AllowedStatuses,
+			AllowedStatuses: rc.DomainConfig.Cache.EffectiveAllowedStatuses(),
 			AllowedMethods:  rc.DomainConfig.Cache.AllowedMethods,
 			DomainID:        rc.DomainConfig.Server.Upstream.GetDomainID(),
 			CurrentURIObject: cache.URIObj{

--- a/server/storage/storage.go
+++ b/server/storage/storage.go
@@ -13,6 +13,7 @@ import (
 	"context"
 	"net/http"
 	"strings"
+	"time"
 
 	log "github.com/sirupsen/logrus"
 
@@ -59,10 +60,24 @@ func RetrieveCachedContent(ctx context.Context, rc RequestCallDTO, logger *log.E
 	return rc.CacheObject.CurrentURIObject, nil
 }
 
+// ApplyNegativeTTL - Overrides the TTL for a configured status (e.g. 404/502)
+// with its own short TTL instead of inheriting origin cache headers, which
+// error pages rarely set sanely. This shields the origin from repeated hits
+// on a broken URL.
+func ApplyNegativeTTL(status int, negativeTTL map[int]int, defaultTTL time.Duration) time.Duration {
+	if secs, ok := negativeTTL[status]; ok {
+		return time.Duration(secs) * time.Second
+	}
+
+	return defaultTTL
+}
+
 // StoreGeneratedPage - Stores a response in the cache.
 func StoreGeneratedPage(ctx context.Context, rc RequestCallDTO, domainConfigCache config.Cache) (bool, error) {
 	// Use the static rc.CacheObject.CurrentURIObject.ResponseHeaders to avoid data race
 	currentTTL := ttl.GetTTL(rc.CacheObject.CurrentURIObject.ResponseHeaders, domainConfigCache.TTL)
+	currentTTL = ApplyNegativeTTL(rc.CacheObject.CurrentURIObject.StatusCode, domainConfigCache.NegativeTTL, currentTTL)
+
 	done, err := rc.CacheObject.StoreFullPage(ctx, currentTTL)
 
 	return done, err

--- a/server/storage/storage_test.go
+++ b/server/storage/storage_test.go
@@ -1,0 +1,42 @@
+//go:build all || unit
+// +build all unit
+
+package storage_test
+
+//                                                                         __
+// .-----.-----.______.-----.----.-----.--.--.--.--.______.----.---.-.----|  |--.-----.
+// |  _  |  _  |______|  _  |   _|  _  |_   _|  |  |______|  __|  _  |  __|     |  -__|
+// |___  |_____|      |   __|__| |_____|__.__|___  |      |____|___._|____|__|__|_____|
+// |_____|            |__|                   |_____|
+//
+// Copyright (c) 2023 Fabio Cicerchia. https://fabiocicerchia.it. MIT License
+// Repo: https://github.com/fabiocicerchia/go-proxy-cache
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/fabiocicerchia/go-proxy-cache/server/storage"
+)
+
+// --- ApplyNegativeTTL
+
+func TestApplyNegativeTTLWithOverride(t *testing.T) {
+	value := storage.ApplyNegativeTTL(404, map[int]int{404: 30, 502: 10}, 3600*time.Second)
+
+	assert.Equal(t, 30*time.Second, value)
+}
+
+func TestApplyNegativeTTLWithoutOverride(t *testing.T) {
+	value := storage.ApplyNegativeTTL(200, map[int]int{404: 30}, 3600*time.Second)
+
+	assert.Equal(t, 3600*time.Second, value)
+}
+
+func TestApplyNegativeTTLWithNilMap(t *testing.T) {
+	value := storage.ApplyNegativeTTL(200, nil, 3600*time.Second)
+
+	assert.Equal(t, 3600*time.Second, value)
+}


### PR DESCRIPTION
## Summary
- Adds `Cache.NegativeTTL` (YAML-only, `map[status]seconds`) so error responses (e.g. 404, 502) get a short, explicitly configured TTL instead of inheriting origin `Cache-Control`/`Expires` headers, which error pages rarely set sanely. Shields the origin from repeated hits on a broken URL.
- Statuses with a `NegativeTTL` entry are implicitly merged into the allowed-statuses check (`Cache.EffectiveAllowedStatuses`), so operators don't need to list the same status in both `allowed_statuses` and `negative_ttl`.
- Per-domain overrides come for free — `NegativeTTL` is just a field on the existing per-domain `Cache` config struct.

## Config example
```yaml
cache:
  negative_ttl:
    404: 30
    502: 10
```

## Explicitly skipped (YAGNI)
- No envconfig/env-var binding for `NegativeTTL` — `kelseyhightower/envconfig` has no clean `map[int]int` support, unlike the existing slice fields. YAML-only, consistent with how this repo already handles fields envconfig can't express well.
- No stale-while-revalidate/serve-stale-on-error semantics from Trickster's doc — out of scope; this PR only addresses TTL-per-status for negative caching.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test -tags=unit ./...` (full suite passes)
- [x] New unit tests: `config.TestEffectiveAllowedStatuses*`, `storage.TestApplyNegativeTTL*`

Closes #58