### PR TITLE
Collapsed forwarding: coalesce concurrent cache-miss requests

### DIFF
--- a/config.yml.dist
+++ b/config.yml.dist
@@ -200,6 +200,10 @@ server:
     # Status code to be used when redirecting HTTP to HTTPS.
     # Default: 301
     redirect_status_code: 301
+    # Collapse concurrent identical GET/HEAD cache misses into a single
+    # upstream request.
+    # Default: false
+    collapsed_forwarding: false
     health_check:
       # Status codes for healthy node.
       # A list of space-separated status codes.

--- a/config/config.go
+++ b/config/config.go
@@ -229,6 +229,7 @@ func (c *Configuration) copyOverWithUpstream(overrides Server) {
 	c.Server.Upstream.HealthCheck.Port = utils.Coalesce(overrides.Upstream.HealthCheck.Port, c.Server.Upstream.HealthCheck.Port).(string)
 	c.Server.Upstream.HealthCheck.Scheme = utils.Coalesce(overrides.Upstream.HealthCheck.Scheme, c.Server.Upstream.HealthCheck.Scheme).(string)
 	c.Server.Upstream.HealthCheck.AllowInsecure = utils.Coalesce(overrides.Upstream.HealthCheck.AllowInsecure, c.Server.Upstream.HealthCheck.AllowInsecure).(bool)
+	c.Server.Upstream.CollapsedForwarding = utils.Coalesce(overrides.Upstream.CollapsedForwarding, c.Server.Upstream.CollapsedForwarding).(bool)
 
 	c.Server.Upstream.Scheme = utils.IfEmpty(c.Server.Upstream.Scheme, SchemeWildcard)
 }

--- a/config/model.go
+++ b/config/model.go
@@ -126,6 +126,10 @@ type Upstream struct {
 	HTTP2HTTPS         bool        `yaml:"http_to_https" envconfig:"HTTP2HTTPS"`
 	RedirectStatusCode int         `yaml:"redirect_status_code" envconfig:"REDIRECT_STATUS_CODE" default:"301"`
 	HealthCheck        HealthCheck `yaml:"health_check"`
+	// CollapsedForwarding - Feature flag for collapsed forwarding, off by
+	// default. When true, concurrent identical GET/HEAD cache misses are
+	// coalesced into a single upstream round-trip.
+	CollapsedForwarding bool `yaml:"collapsed_forwarding" envconfig:"COLLAPSED_FORWARDING"`
 }
 
 // GetDomainID - Returns the unique ID for the upstream.

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -9,6 +9,7 @@
 - `BALANCING_ALGORITHM` = `round-robin`
 - `CACHE_ALLOWED_METHODS`
 - `CACHE_ALLOWED_STATUSES`
+- `COLLAPSED_FORWARDING`
 - `DEFAULT_TTL`
 - `FORWARD_HOST`
 - `FORWARD_PORT`
@@ -232,6 +233,10 @@ server:
     # Status code to be used when redirecting HTTP to HTTPS.
     # Default: 301
     redirect_status_code: 301
+    # Collapse concurrent identical GET/HEAD cache misses into a single
+    # upstream request.
+    # Default: false
+    collapsed_forwarding: false
     health_check:
       # Status codes for healthy node.
       # A list of space-separated status codes.

--- a/go.mod
+++ b/go.mod
@@ -28,6 +28,7 @@ require (
 	go.opentelemetry.io/otel/trace v1.44.0
 	golang.org/x/crypto v0.54.0
 	golang.org/x/net v0.57.0
+	golang.org/x/sync v0.22.0
 	gopkg.in/yaml.v2 v2.4.0
 )
 
@@ -57,7 +58,6 @@ require (
 	github.com/segmentio/asm v1.2.1 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/otel/metric v1.44.0 // indirect
-	golang.org/x/sync v0.22.0 // indirect
 	golang.org/x/sys v0.47.0 // indirect
 	golang.org/x/text v0.40.0 // indirect
 	google.golang.org/protobuf v1.36.11 // indirect

--- a/server/handler/coalesce.go
+++ b/server/handler/coalesce.go
@@ -42,6 +42,17 @@ type coalescingRoundTripper struct {
 	http.RoundTripper
 }
 
+// proxyTransport - Returns the transport for the reverse proxy, wrapped in the
+// coalescing decorator only when collapsed forwarding is enabled for the domain
+// (feature flag, off by default).
+func (rc RequestCall) proxyTransport() http.RoundTripper {
+	if rc.DomainConfig.Server.Upstream.CollapsedForwarding {
+		return coalescingRoundTripper{rc.patchProxyTransport()}
+	}
+
+	return rc.patchProxyTransport()
+}
+
 func (c coalescingRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
 	if req.Method != http.MethodGet && req.Method != http.MethodHead {
 		return c.RoundTripper.RoundTrip(req)

--- a/server/handler/coalesce.go
+++ b/server/handler/coalesce.go
@@ -1,0 +1,82 @@
+package handler
+
+//                                                                         __
+// .-----.-----.______.-----.----.-----.--.--.--.--.______.----.---.-.----|  |--.-----.
+// |  _  |  _  |______|  _  |   _|  _  |_   _|  |  |______|  __|  _  |  __|     |  -__|
+// |___  |_____|      |   __|__| |_____|__.__|___  |      |____|___._|____|__|__|_____|
+// |_____|            |__|                   |_____|
+//
+// Copyright (c) 2023 Fabio Cicerchia. https://fabiocicerchia.it. MIT License
+// Repo: https://github.com/fabiocicerchia/go-proxy-cache
+
+import (
+	"bytes"
+	"io"
+	"net/http"
+
+	"golang.org/x/sync/singleflight"
+)
+
+// reverseProxyGroup - Coalesces concurrent identical upstream fetches
+// (collapsed forwarding), so a cache-miss stampede for the same resource
+// hits the origin once instead of once per concurrent request.
+var reverseProxyGroup singleflight.Group
+
+// coalescedResponse - Buffered upstream response shared across all callers
+// waiting on the same singleflight key.
+type coalescedResponse struct {
+	resp *http.Response
+	body []byte
+}
+
+// coalescingRoundTripper - http.RoundTripper decorator that collapses
+// concurrent GET/HEAD requests for the same URL into a single upstream
+// round-trip. Only GET/HEAD are coalesced: they're safe to share across
+// callers, unlike POST/PURGE which carry per-caller semantics/bodies.
+//
+// ponytail: keyed on method+URL only, not Vary-aware (matches how the
+// upstream response's Vary headers aren't known until after the fetch).
+// Upgrade to a Vary-aware key if a coalesced backend actually varies
+// per-request in a way that matters.
+type coalescingRoundTripper struct {
+	http.RoundTripper
+}
+
+func (c coalescingRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	if req.Method != http.MethodGet && req.Method != http.MethodHead {
+		return c.RoundTripper.RoundTrip(req)
+	}
+
+	key := req.Method + " " + req.URL.String()
+
+	v, err, _ := reverseProxyGroup.Do(key, func() (interface{}, error) {
+		resp, err := c.RoundTripper.RoundTrip(req)
+		if err != nil {
+			return nil, err
+		}
+
+		body, err := io.ReadAll(resp.Body)
+		_ = resp.Body.Close()
+		if err != nil {
+			return nil, err
+		}
+
+		return &coalescedResponse{resp: resp, body: body}, nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	cr := v.(*coalescedResponse)
+
+	// Each waiter gets its own *http.Response/body/header, so downstream
+	// per-request logic (ETag, gzip, cache storage) can freely read/mutate
+	// its copy without racing the other waiters.
+	respCopy := *cr.resp
+	respCopy.Request = req
+	respCopy.Header = cr.resp.Header.Clone()
+	respCopy.Body = io.NopCloser(bytes.NewReader(cr.body))
+	respCopy.ContentLength = int64(len(cr.body))
+
+	return &respCopy, nil
+}

--- a/server/handler/coalesce_test.go
+++ b/server/handler/coalesce_test.go
@@ -1,0 +1,90 @@
+//go:build all || unit
+// +build all unit
+
+package handler
+
+//                                                                         __
+// .-----.-----.______.-----.----.-----.--.--.--.--.______.----.---.-.----|  |--.-----.
+// |  _  |  _  |______|  _  |   _|  _  |_   _|  |  |______|  __|  _  |  __|     |  -__|
+// |___  |_____|      |   __|__| |_____|__.__|___  |      |____|___._|____|__|__|_____|
+// |_____|            |__|                   |_____|
+//
+// Copyright (c) 2023 Fabio Cicerchia. https://fabiocicerchia.it. MIT License
+// Repo: https://github.com/fabiocicerchia/go-proxy-cache
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCoalescingRoundTripperCollapsesConcurrentGETs(t *testing.T) {
+	var hits int32
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&hits, 1)
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("hello"))
+	}))
+	defer upstream.Close()
+
+	rt := coalescingRoundTripper{http.DefaultTransport}
+
+	const n = 20
+	var wg sync.WaitGroup
+	wg.Add(n)
+	for i := 0; i < n; i++ {
+		go func() {
+			defer wg.Done()
+
+			req, err := http.NewRequest(http.MethodGet, upstream.URL, nil)
+			assert.NoError(t, err)
+
+			resp, err := rt.RoundTrip(req)
+			assert.NoError(t, err)
+			defer resp.Body.Close()
+
+			body, err := io.ReadAll(resp.Body)
+			assert.NoError(t, err)
+			assert.Equal(t, "hello", string(body))
+			assert.Equal(t, http.StatusOK, resp.StatusCode)
+		}()
+	}
+	wg.Wait()
+
+	assert.Less(t, int(atomic.LoadInt32(&hits)), n, "concurrent identical GETs should be collapsed into fewer upstream hits")
+}
+
+func TestCoalescingRoundTripperDoesNotCollapsePOST(t *testing.T) {
+	var hits int32
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&hits, 1)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer upstream.Close()
+
+	rt := coalescingRoundTripper{http.DefaultTransport}
+
+	const n = 5
+	var wg sync.WaitGroup
+	wg.Add(n)
+	for i := 0; i < n; i++ {
+		go func() {
+			defer wg.Done()
+			req, err := http.NewRequest(http.MethodPost, upstream.URL, nil)
+			assert.NoError(t, err)
+			resp, err := rt.RoundTrip(req)
+			assert.NoError(t, err)
+			_ = resp.Body.Close()
+		}()
+	}
+	wg.Wait()
+
+	assert.EqualValues(t, n, hits, "POST requests must never be coalesced")
+}

--- a/server/handler/coalesce_test.go
+++ b/server/handler/coalesce_test.go
@@ -23,6 +23,16 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func TestCollapsedForwardingFeatureFlag(t *testing.T) {
+	rc := RequestCall{}
+
+	assert.IsType(t, &http.Transport{}, rc.proxyTransport())
+
+	rc.DomainConfig.Server.Upstream.CollapsedForwarding = true
+
+	assert.IsType(t, coalescingRoundTripper{}, rc.proxyTransport())
+}
+
 func TestCoalescingRoundTripperCollapsesConcurrentGETs(t *testing.T) {
 	var hits int32
 

--- a/server/handler/http.go
+++ b/server/handler/http.go
@@ -128,7 +128,7 @@ func (rc RequestCall) serveReverseProxyHTTP(ctx context.Context) {
 	telemetry.From(ctx).RegisterRequestUpstream(proxyURL, enableCachedResponse, cache.StatusLabel[cache.StatusMiss])
 
 	proxy := httputil.NewSingleHostReverseProxy(&proxyURL)
-	proxy.Transport = coalescingRoundTripper{rc.patchProxyTransport()}
+	proxy.Transport = rc.proxyTransport()
 
 	originalDirector := proxy.Director
 	gpcDirector := rc.ProxyDirector(ctx)

--- a/server/handler/http.go
+++ b/server/handler/http.go
@@ -128,7 +128,7 @@ func (rc RequestCall) serveReverseProxyHTTP(ctx context.Context) {
 	telemetry.From(ctx).RegisterRequestUpstream(proxyURL, enableCachedResponse, cache.StatusLabel[cache.StatusMiss])
 
 	proxy := httputil.NewSingleHostReverseProxy(&proxyURL)
-	proxy.Transport = rc.patchProxyTransport()
+	proxy.Transport = coalescingRoundTripper{rc.patchProxyTransport()}
 
 	originalDirector := proxy.Director
 	gpcDirector := rc.ProxyDirector(ctx)


### PR DESCRIPTION
## What
Coalesces concurrent identical GET/HEAD requests for the same not-yet-cached URL into a single upstream round-trip, instead of letting every concurrent request hit the origin (cache-miss thundering herd).

## How
Wraps the per-request `http.Transport` (`server/handler/utils.go#patchProxyTransport`) with a `coalescingRoundTripper` (`server/handler/coalesce.go`) built on `golang.org/x/sync/singleflight`, which was already an indirect dependency (promoted to direct — no new dependency added).

- Only GET/HEAD are coalesced. POST/PURGE and other methods always get their own independent round-trip (coalescing a POST would silently merge different request bodies — a correctness bug).
- The leader request performs the real fetch and fully buffers the response body; every waiter gets its own cloned `*http.Response` (own `Header`, own `Body` reader) so downstream per-request logic (ETag computation, gzip, cache storage) still runs independently per request, unaffected by coalescing.
- Keyed on `method + URL` only.

## Skipped (noted in code as `ponytail:`)
- **Vary-aware keying**: the key doesn't account for `Vary` request headers (e.g. `Accept-Encoding`), since the response's `Vary` header isn't known until after the fetch completes. Acceptable approximation for a first cut — upgrade to a Vary-sensitive key if a coalesced backend actually needs it.
- **Cross-process coalescing**: this only collapses requests within a single proxy instance/process. Coalescing across multiple proxy replicas would need a distributed lock (e.g. via Redis) — a much bigger feature, out of scope here.
- This is orthogonal to the existing soft/hard TTL stale-while-revalidate mechanism in `cache/cache.go` (`FreshSuffix`, `getRandomSoftExpirationTTL`), which already mitigates *stale-refresh* stampedes. This PR specifically addresses *cold cache-miss* stampedes.

Closes #57