### PR TITLE
fix(security): configurable HSTS header to mitigate MITM/SSL-stripping

### DIFF
--- a/config/model.go
+++ b/config/model.go
@@ -12,6 +12,7 @@ package config
 import (
 	"context"
 	"crypto/tls"
+	"fmt"
 	"net/http"
 	"time"
 
@@ -113,6 +114,35 @@ type TLS struct {
 	// cached. Must be persistent: an ephemeral directory forces re-issuance on
 	// every restart, burning through the CA's rate limits.
 	CertCacheDir string `yaml:"cert_cache_dir" envconfig:"TLS_CERT_CACHE_DIR"`
+	HSTS         HSTS   `yaml:"hsts"`
+}
+
+// HSTS - Defines the configuration for the Strict-Transport-Security header.
+// Mitigates MITM/SSL-stripping attacks by telling browsers to never
+// downgrade this host to plain HTTP again, once seen over HTTPS.
+type HSTS struct {
+	Enabled           bool `yaml:"enabled" envconfig:"TLS_HSTS_ENABLED"`
+	MaxAge            int  `yaml:"max_age" envconfig:"TLS_HSTS_MAX_AGE" default:"31536000"`
+	IncludeSubdomains bool `yaml:"include_subdomains" envconfig:"TLS_HSTS_INCLUDE_SUBDOMAINS"`
+	Preload           bool `yaml:"preload" envconfig:"TLS_HSTS_PRELOAD"`
+}
+
+// Header - Builds the Strict-Transport-Security header value.
+func (h HSTS) Header() string {
+	maxAge := h.MaxAge
+	if maxAge == 0 {
+		maxAge = 31536000 // 1 year, matches the envconfig default.
+	}
+
+	value := fmt.Sprintf("max-age=%d", maxAge)
+	if h.IncludeSubdomains {
+		value += "; includeSubDomains"
+	}
+	if h.Preload {
+		value += "; preload"
+	}
+
+	return value
 }
 
 // Upstream - Defines the upstream settings.

--- a/server/handler/handler.go
+++ b/server/handler/handler.go
@@ -46,6 +46,8 @@ func HandleRequest(res http.ResponseWriter, req *http.Request) {
 
 	telemetry.From(ctx).RegisterRequestCall(rc.ReqID, rc.Request, rc.GetRequestURL(), rc.GetScheme(), rc.IsWebSocket())
 
+	rc.SetHSTSHeader()
+
 	if rc.Request.Method == http.MethodConnect {
 		if enableLoggingRequest {
 			logger.LogRequest(rc.Request, rc.Response.StatusCode, rc.Response.Content.Len(), rc.ReqID, cache.StatusNA)

--- a/server/handler/hsts.go
+++ b/server/handler/hsts.go
@@ -1,0 +1,23 @@
+package handler
+
+//                                                                         __
+// .-----.-----.______.-----.----.-----.--.--.--.--.______.----.---.-.----|  |--.-----.
+// |  _  |  _  |______|  _  |   _|  _  |_   _|  |  |______|  __|  _  |  __|     |  -__|
+// |___  |_____|      |   __|__| |_____|__.__|___  |      |____|___._|____|__|__|_____|
+// |_____|            |__|                   |_____|
+//
+// Copyright (c) 2023 Fabio Cicerchia. https://fabiocicerchia.it. MIT License
+// Repo: https://github.com/fabiocicerchia/go-proxy-cache
+
+import "github.com/go-http-utils/headers"
+
+// SetHSTSHeader - Adds Strict-Transport-Security to HTTPS responses when
+// enabled, mitigating MITM/SSL-stripping downgrade attacks (#11).
+func (rc RequestCall) SetHSTSHeader() {
+	hsts := rc.DomainConfig.Server.TLS.HSTS
+	if !hsts.Enabled || rc.GetScheme() != SchemeHTTPS {
+		return
+	}
+
+	rc.Response.Header().Set(headers.StrictTransportSecurity, hsts.Header())
+}

--- a/server/handler/hsts_test.go
+++ b/server/handler/hsts_test.go
@@ -1,0 +1,76 @@
+//go:build all || unit
+// +build all unit
+
+package handler_test
+
+//                                                                         __
+// .-----.-----.______.-----.----.-----.--.--.--.--.______.----.---.-.----|  |--.-----.
+// |  _  |  _  |______|  _  |   _|  _  |_   _|  |  |______|  __|  _  |  __|     |  -__|
+// |___  |_____|      |   __|__| |_____|__.__|___  |      |____|___._|____|__|__|_____|
+// |_____|            |__|                   |_____|
+//
+// Copyright (c) 2023 Fabio Cicerchia. https://fabiocicerchia.it. MIT License
+// Repo: https://github.com/fabiocicerchia/go-proxy-cache
+
+import (
+	"crypto/tls"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/fabiocicerchia/go-proxy-cache/config"
+	"github.com/fabiocicerchia/go-proxy-cache/server/handler"
+)
+
+func TestSetHSTSHeaderEnabledOverHTTPS(t *testing.T) {
+	reqMock := http.Request{TLS: &tls.ConnectionState{}}
+
+	r := handler.NewRequestCall(httptest.NewRecorder(), &reqMock)
+	r.DomainConfig = config.Configuration{
+		Server: config.Server{
+			TLS: config.TLS{
+				HSTS: config.HSTS{Enabled: true, MaxAge: 63072000, IncludeSubdomains: true, Preload: true},
+			},
+		},
+	}
+
+	r.SetHSTSHeader()
+
+	assert.Equal(t, "max-age=63072000; includeSubDomains; preload", r.Response.Header().Get("Strict-Transport-Security"))
+}
+
+func TestSetHSTSHeaderAbsentOverPlainHTTP(t *testing.T) {
+	reqMock := http.Request{} // TLS == nil -> plain HTTP
+
+	r := handler.NewRequestCall(httptest.NewRecorder(), &reqMock)
+	r.DomainConfig = config.Configuration{
+		Server: config.Server{
+			TLS: config.TLS{
+				HSTS: config.HSTS{Enabled: true},
+			},
+		},
+	}
+
+	r.SetHSTSHeader()
+
+	assert.Empty(t, r.Response.Header().Get("Strict-Transport-Security"))
+}
+
+func TestSetHSTSHeaderAbsentWhenDisabled(t *testing.T) {
+	reqMock := http.Request{TLS: &tls.ConnectionState{}}
+
+	r := handler.NewRequestCall(httptest.NewRecorder(), &reqMock)
+	r.DomainConfig = config.Configuration{
+		Server: config.Server{
+			TLS: config.TLS{
+				HSTS: config.HSTS{Enabled: false},
+			},
+		},
+	}
+
+	r.SetHSTSHeader()
+
+	assert.Empty(t, r.Response.Header().Get("Strict-Transport-Security"))
+}


### PR DESCRIPTION
## Why

Issue #11 has no body/comments (filed 2020) — it's a vague request for MITM protection. Investigating the existing TLS setup:

- `server/tls/tls.go` already enforces a sane `MinVersion` (TLS 1.2 default, configurable), modern cipher suites, and curve preferences.
- `server/handler/redirect.go` already redirects HTTP -> HTTPS correctly.
- **Missing:** no `Strict-Transport-Security` header anywhere. Without it, a MITM can intercept the client's very first plaintext request (or the redirect response) and simply never let the browser upgrade to HTTPS again — a classic SSL-stripping attack. HSTS is the standard, minimal fix.

## What changed

- New `server.tls.hsts` config block (`enabled`, `max_age`, `include_subdomains`, `preload`), opt-in (disabled by default — some deployments terminate TLS elsewhere or serve HTTP-only internal traffic where forcing this would break things).
- `RequestCall.SetHSTSHeader()` sets the header on every response, but only when the request is over HTTPS and HSTS is enabled for that domain.
- Wired into the single `HandleRequest` entrypoint so it applies uniformly (proxy, PURGE, WebSocket), not just one code path.
- Unit tests covering: enabled+HTTPS sets the header, HTTP never gets it, disabled never gets it.

## Explicitly out of scope

- mTLS / client certificate auth (that's issue #36).
- Certificate pinning.
- TLS cipher/version hardening — already solid, untouched by this PR.

Closes #11