### PR TITLE
cache: add freecache as a pluggable in-process backend

### DIFF
--- a/cache/engine/client/freecache.go
+++ b/cache/engine/client/freecache.go
@@ -1,0 +1,157 @@
+package client
+
+//                                                                         __
+// .-----.-----.______.-----.----.-----.--.--.--.--.______.----.---.-.----|  |--.-----.
+// |  _  |  _  |______|  _  |   _|  _  |_   _|  |  |______|  __|  _  |  __|     |  -__|
+// |___  |_____|      |   __|__| |_____|__.__|___  |      |____|___._|____|__|__|_____|
+// |_____|            |__|                   |_____|
+//
+// Copyright (c) 2023 Fabio Cicerchia. https://fabiocicerchia.it. MIT License
+// Repo: https://github.com/fabiocicerchia/go-proxy-cache
+
+import (
+	"context"
+	"encoding/json"
+	"path"
+	"time"
+
+	"github.com/coocood/freecache"
+
+	"github.com/fabiocicerchia/go-proxy-cache/config"
+	"github.com/fabiocicerchia/go-proxy-cache/utils/base64"
+	"github.com/fabiocicerchia/go-proxy-cache/utils/msgpack"
+)
+
+const defaultFreecacheSizeMB = 100
+
+// FreecacheClient - In-process, single-instance cache backend. No network
+// hop, no external infra, but also no sharing across proxy replicas and no
+// wildcard index beyond an O(n) full scan (see DelWildcard below).
+type FreecacheClient struct {
+	cache *freecache.Cache
+}
+
+// NewFreecacheClient - Builds an in-process cache backend sized from config
+// (defaults to 100MB when unset).
+func NewFreecacheClient(cfg config.Cache) *FreecacheClient {
+	sizeMB := cfg.FreecacheSizeMB
+	if sizeMB <= 0 {
+		sizeMB = defaultFreecacheSizeMB
+	}
+
+	return &FreecacheClient{cache: freecache.NewCache(sizeMB * 1024 * 1024)}
+}
+
+var _ CacheClient = (*FreecacheClient)(nil)
+
+// Set - Sets a key with a TTL. expiration <= 0 means no expiry.
+func (f *FreecacheClient) Set(_ context.Context, key string, value string, expiration time.Duration) (bool, error) {
+	err := f.cache.Set([]byte(key), []byte(value), int(expiration.Seconds()))
+	return err == nil, err
+}
+
+// Get - Gets a key. A cache miss returns ("", nil), matching the Redis
+// client's treatment of a missing key as an empty, non-error value.
+func (f *FreecacheClient) Get(key string) (string, error) {
+	value, err := f.cache.Get([]byte(key))
+	if err == freecache.ErrNotFound {
+		return "", nil
+	}
+	if err != nil {
+		return "", err
+	}
+
+	return string(value), nil
+}
+
+// Del - Removes a key.
+func (f *FreecacheClient) Del(_ context.Context, key string) error {
+	f.cache.Del([]byte(key))
+	return nil
+}
+
+// DelWildcard - Removes keys matching a glob pattern (the same "*" pattern
+// syntax already produced by cache/cache.go for Redis KEYS).
+// ponytail: full scan via freecache's iterator, no key index - fine for the
+// in-process/small-scale use case this backend targets. Add a prefix index
+// if PURGE on a large freecache instance ever shows up as slow.
+func (f *FreecacheClient) DelWildcard(_ context.Context, keyPattern string) (int, error) {
+	it := f.cache.NewIterator()
+	var matched [][]byte
+	for entry := it.Next(); entry != nil; entry = it.Next() {
+		if ok, _ := path.Match(keyPattern, string(entry.Key)); ok {
+			matched = append(matched, entry.Key)
+		}
+	}
+
+	for _, key := range matched {
+		f.cache.Del(key)
+	}
+
+	return len(matched), nil
+}
+
+// List - Returns a JSON-encoded []string previously stored via Push.
+func (f *FreecacheClient) List(key string) ([]string, error) {
+	value, err := f.cache.Get([]byte(key))
+	if err == freecache.ErrNotFound {
+		return []string{}, nil
+	}
+	if err != nil {
+		return []string{}, err
+	}
+
+	var values []string
+	if err := json.Unmarshal(value, &values); err != nil {
+		return []string{}, err
+	}
+
+	return values, nil
+}
+
+// Push - Appends values to the list stored at key. expiration is not reset
+// here to mirror Redis RPUSH, which doesn't touch TTL either; callers set it
+// separately via Expire, same as the Redis backend.
+func (f *FreecacheClient) Push(_ context.Context, key string, values []string) error {
+	existing, err := f.List(key)
+	if err != nil {
+		return err
+	}
+
+	encoded, err := json.Marshal(append(existing, values...))
+	if err != nil {
+		return err
+	}
+
+	return f.cache.Set([]byte(key), encoded, 0)
+}
+
+// Expire - Sets a TTL on an existing key.
+func (f *FreecacheClient) Expire(key string, expiration time.Duration) error {
+	return f.cache.Touch([]byte(key), int(expiration.Seconds()))
+}
+
+// Encode - Encodes an object with msgpack, same wire format as the Redis backend.
+func (f *FreecacheClient) Encode(obj interface{}) (string, error) {
+	value, err := msgpack.Encode(obj)
+	if err != nil {
+		return "", err
+	}
+
+	return base64.Encode(value), nil
+}
+
+// Decode - Decodes an object with msgpack, same wire format as the Redis backend.
+func (f *FreecacheClient) Decode(encoded string, obj interface{}) error {
+	decoded, err := base64.Decode(encoded)
+	if err != nil {
+		return err
+	}
+
+	return msgpack.Decode(decoded, obj)
+}
+
+// Ping - Always available; there's no network connection to check.
+func (f *FreecacheClient) Ping() bool {
+	return true
+}

--- a/cache/engine/client/freecache_test.go
+++ b/cache/engine/client/freecache_test.go
@@ -1,0 +1,111 @@
+//go:build all || unit
+// +build all unit
+
+package client
+
+//                                                                         __
+// .-----.-----.______.-----.----.-----.--.--.--.--.______.----.---.-.----|  |--.-----.
+// |  _  |  _  |______|  _  |   _|  _  |_   _|  |  |______|  __|  _  |  __|     |  -__|
+// |___  |_____|      |   __|__| |_____|__.__|___  |      |____|___._|____|__|__|_____|
+// |_____|            |__|                   |_____|
+//
+// Copyright (c) 2023 Fabio Cicerchia. https://fabiocicerchia.it. MIT License
+// Repo: https://github.com/fabiocicerchia/go-proxy-cache/
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/fabiocicerchia/go-proxy-cache/config"
+)
+
+func TestFreecacheClientSetGet(t *testing.T) {
+	fc := NewFreecacheClient(config.Cache{})
+
+	ok, err := fc.Set(context.Background(), "k1", "v1", time.Minute)
+	assert.True(t, ok)
+	assert.NoError(t, err)
+
+	value, err := fc.Get("k1")
+	assert.NoError(t, err)
+	assert.Equal(t, "v1", value)
+}
+
+func TestFreecacheClientGetMissReturnsEmptyNoError(t *testing.T) {
+	fc := NewFreecacheClient(config.Cache{})
+
+	value, err := fc.Get("missing")
+	assert.NoError(t, err)
+	assert.Equal(t, "", value)
+}
+
+func TestFreecacheClientDel(t *testing.T) {
+	fc := NewFreecacheClient(config.Cache{})
+
+	_, _ = fc.Set(context.Background(), "k1", "v1", time.Minute)
+	assert.NoError(t, fc.Del(context.Background(), "k1"))
+
+	value, err := fc.Get("k1")
+	assert.NoError(t, err)
+	assert.Equal(t, "", value)
+}
+
+func TestFreecacheClientDelWildcard(t *testing.T) {
+	fc := NewFreecacheClient(config.Cache{})
+
+	_, _ = fc.Set(context.Background(), "DATA|GET|foo", "v1", time.Minute)
+	_, _ = fc.Set(context.Background(), "DATA|GET|bar", "v2", time.Minute)
+	_, _ = fc.Set(context.Background(), "META|GET|foo", "v3", time.Minute)
+
+	affected, err := fc.DelWildcard(context.Background(), "DATA|*")
+	assert.NoError(t, err)
+	assert.Equal(t, 2, affected)
+
+	value, _ := fc.Get("META|GET|foo")
+	assert.Equal(t, "v3", value, "non-matching key must survive")
+}
+
+func TestFreecacheClientPushAndList(t *testing.T) {
+	fc := NewFreecacheClient(config.Cache{})
+
+	assert.NoError(t, fc.Push(context.Background(), "list1", []string{"a", "b"}))
+	assert.NoError(t, fc.Push(context.Background(), "list1", []string{"c"}))
+
+	values, err := fc.List("list1")
+	assert.NoError(t, err)
+	assert.Equal(t, []string{"a", "b", "c"}, values)
+}
+
+func TestFreecacheClientListMissingReturnsEmpty(t *testing.T) {
+	fc := NewFreecacheClient(config.Cache{})
+
+	values, err := fc.List("missing")
+	assert.NoError(t, err)
+	assert.Equal(t, []string{}, values)
+}
+
+func TestFreecacheClientEncodeDecodeRoundTrip(t *testing.T) {
+	fc := NewFreecacheClient(config.Cache{})
+
+	type payload struct{ Name string }
+
+	encoded, err := fc.Encode(payload{Name: "test"})
+	assert.NoError(t, err)
+
+	var out payload
+	assert.NoError(t, fc.Decode(encoded, &out))
+	assert.Equal(t, "test", out.Name)
+}
+
+func TestFreecacheClientPing(t *testing.T) {
+	fc := NewFreecacheClient(config.Cache{})
+	assert.True(t, fc.Ping())
+}
+
+func TestNewFreecacheClientDefaultsSize(t *testing.T) {
+	fc := NewFreecacheClient(config.Cache{FreecacheSizeMB: 0})
+	assert.NotNil(t, fc.cache)
+}

--- a/cache/engine/client/interface.go
+++ b/cache/engine/client/interface.go
@@ -1,0 +1,33 @@
+package client
+
+//                                                                         __
+// .-----.-----.______.-----.----.-----.--.--.--.--.______.----.---.-.----|  |--.-----.
+// |  _  |  _  |______|  _  |   _|  _  |_   _|  |  |______|  __|  _  |  __|     |  -__|
+// |___  |_____|      |   __|__| |_____|__.__|___  |      |____|___._|____|__|__|_____|
+// |_____|            |__|                   |_____|
+//
+// Copyright (c) 2023 Fabio Cicerchia. https://fabiocicerchia.it. MIT License
+// Repo: https://github.com/fabiocicerchia/go-proxy-cache
+
+import (
+	"context"
+	"time"
+)
+
+// CacheClient - Minimal set of operations a cache backend must support.
+// Method set matches exactly what cache/cache.go and the health check use
+// against *RedisClient today - nothing speculative.
+type CacheClient interface {
+	Set(ctx context.Context, key string, value string, expiration time.Duration) (bool, error)
+	Get(key string) (string, error)
+	Del(ctx context.Context, key string) error
+	DelWildcard(ctx context.Context, key string) (int, error)
+	List(key string) ([]string, error)
+	Push(ctx context.Context, key string, values []string) error
+	Expire(key string, expiration time.Duration) error
+	Encode(obj interface{}) (string, error)
+	Decode(encoded string, obj interface{}) error
+	Ping() bool
+}
+
+var _ CacheClient = (*RedisClient)(nil)

--- a/cache/engine/redis.go
+++ b/cache/engine/redis.go
@@ -30,10 +30,18 @@ func GetConn(connName string) client.CacheClient {
 	return nil
 }
 
-// InitConn - Initialises the cache backend connection.
+// InitConn - Initialises the cache backend connection. config.Cache.Engine
+// selects the backend ("redis", the default, or "freecache" for an
+// in-process, single-instance cache with no external infra).
 func InitConn(connName string, config config.Cache, logger *log.Logger) {
 	if rdb == nil {
 		rdb = make(map[string]client.CacheClient)
+	}
+
+	if config.Engine == "freecache" {
+		logger.Debugf("New freecache connection for %s", connName)
+		rdb[connName] = client.NewFreecacheClient(config)
+		return
 	}
 
 	logger.Debugf("New redis connection for %s", connName)

--- a/cache/engine/redis.go
+++ b/cache/engine/redis.go
@@ -17,23 +17,23 @@ import (
 	"github.com/fabiocicerchia/go-proxy-cache/logger"
 )
 
-var rdb map[string]*client.RedisClient
+var rdb map[string]client.CacheClient
 
-// GetConn - Retrieves the Redis connection.
-func GetConn(connName string) *client.RedisClient {
+// GetConn - Retrieves the cache backend connection.
+func GetConn(connName string) client.CacheClient {
 	if conn, ok := rdb[connName]; ok {
 		return conn
 	}
 
-	logger.GetGlobal().Errorf("Missing redis connection for %s", connName)
+	logger.GetGlobal().Errorf("Missing cache connection for %s", connName)
 
 	return nil
 }
 
-// InitConn - Initialises the Redis connection.
+// InitConn - Initialises the cache backend connection.
 func InitConn(connName string, config config.Cache, logger *log.Logger) {
 	if rdb == nil {
-		rdb = make(map[string]*client.RedisClient)
+		rdb = make(map[string]client.CacheClient)
 	}
 
 	logger.Debugf("New redis connection for %s", connName)

--- a/config/config.go
+++ b/config/config.go
@@ -241,6 +241,8 @@ func (c *Configuration) copyOverWithCache(overrides Cache) {
 	c.Cache.TTL = utils.Coalesce(overrides.TTL, c.Cache.TTL).(int)
 	c.Cache.AllowedStatuses = utils.Coalesce(overrides.AllowedStatuses, c.Cache.AllowedStatuses).([]int)
 	c.Cache.AllowedMethods = utils.Coalesce(overrides.AllowedMethods, c.Cache.AllowedMethods).([]string)
+	c.Cache.Engine = utils.Coalesce(overrides.Engine, c.Cache.Engine).(string)
+	c.Cache.FreecacheSizeMB = utils.Coalesce(overrides.FreecacheSizeMB, c.Cache.FreecacheSizeMB).(int)
 
 	c.Cache.AllowedMethods = append(c.Cache.AllowedMethods, "HEAD", "GET")
 	c.Cache.AllowedMethods = slice.Unique(c.Cache.AllowedMethods)

--- a/config/model.go
+++ b/config/model.go
@@ -160,6 +160,11 @@ type Cache struct {
 	TTL             int      `yaml:"ttl" envconfig:"DEFAULT_TTL"`
 	AllowedStatuses []int    `yaml:"allowed_statuses" envconfig:"CACHE_ALLOWED_STATUSES" split_words:"true"`
 	AllowedMethods  []string `yaml:"allowed_methods" envconfig:"CACHE_ALLOWED_METHODS" split_words:"true"`
+	// Engine - Cache backend to use: "redis" (default) or "freecache" (in-process,
+	// single-instance, no external infra - see cache/engine/client/freecache.go).
+	Engine string `yaml:"engine" envconfig:"CACHE_ENGINE"`
+	// FreecacheSizeMB - In-memory size cap for the freecache backend. Ignored by redis.
+	FreecacheSizeMB int `yaml:"freecache_size_mb" envconfig:"CACHE_FREECACHE_SIZE_MB"`
 }
 
 // Log - Defines the config for the logs.
@@ -267,6 +272,7 @@ var Config Configuration = Configuration{
 		TTL:             0,
 		AllowedStatuses: []int{200, 301, 302},
 		AllowedMethods:  []string{"HEAD", "GET"},
+		Engine:          "redis",
 	},
 	CircuitBreaker: circuitbreaker.CircuitBreaker{
 		Threshold:   DefaultCBThreshold,   // after 2nd request, if meet FailureRate goes open.

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -9,6 +9,8 @@
 - `BALANCING_ALGORITHM` = `round-robin`
 - `CACHE_ALLOWED_METHODS`
 - `CACHE_ALLOWED_STATUSES`
+- `CACHE_ENGINE` = `redis` - Cache backend: `redis` (default) or `freecache` (in-process, single-instance, no external infra).
+- `CACHE_FREECACHE_SIZE_MB` = `100` - In-memory size cap for the `freecache` backend. Ignored by `redis`.
 - `DEFAULT_TTL`
 - `FORWARD_HOST`
 - `FORWARD_PORT`

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/fabiocicerchia/go-proxy-cache
 go 1.25.0
 
 require (
+	github.com/coocood/freecache v1.2.7
 	github.com/evalphobia/logrus_sentry v0.8.2
 	github.com/go-http-utils/fresh v0.0.0-20161124030543-7231e26a4b27
 	github.com/go-http-utils/headers v0.0.0-20181008091004-fed159eddc2a

--- a/go.sum
+++ b/go.sum
@@ -4,6 +4,8 @@ github.com/certifi/gocertifi v0.0.0-20210507211836-431795d63e8d h1:S2NE3iHSwP0XV
 github.com/certifi/gocertifi v0.0.0-20210507211836-431795d63e8d/go.mod h1:sGbDF6GwGcLpkNXPUTkMRoywsNa/ol15pxFe6ERfguA=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
+github.com/coocood/freecache v1.2.7 h1:IDP0x1Yg8sgRmsSWzFyhaB+amYJpKS7v5QIXNHxXvM8=
+github.com/coocood/freecache v1.2.7/go.mod h1:+Ga2+A5/0D6MMistGuoeKZaZucAGZ56u+fYKiY+xqNA=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=


### PR DESCRIPTION
## Summary
Issue #19 asked for support for cache backends beyond Redis (BigCache, FreeCache). This adds **freecache** as a second, minimal `CacheClient` implementation:

- New `CacheClient` interface (prior commit, pure refactor, no behavior change) extracted from `*RedisClient` — only the methods actually called from `cache/cache.go` and the health check.
- `FreecacheClient` implements the same interface in-process, no external infra, no network hop — trade-off: no sharing across proxy replicas, and `DelWildcard` is an O(n) full scan (documented in-code as a known ceiling for large instances).
- Selected via `CACHE_ENGINE=freecache` (default remains `redis`, zero behavior change for existing deployments). Sized via `CACHE_FREECACHE_SIZE_MB` (default 100MB).

Did not add BigCache separately — freecache alone satisfies the issue's actual need (an in-process backend option); a second in-process backend would be pure duplication until someone needs freecache-specific behavior it lacks.

## Test plan
- [x] `go build ./...`
- [x] `go vet -tags unit ./...`
- [x] `go test -tags unit ./...` — full suite green, plus 9 new freecache unit tests (set/get, miss, del, wildcard delete, push/list, encode/decode round-trip, ping, default sizing)

Closes #19

Draft PR — minimal implementation, opening for review/feedback.