### PR TITLE
fix: least-privilege workflow tokens, super-linter v8, and unswallowed errors on the request path

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -24,6 +24,11 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+# The default token is read-only; the analysis job widens it to exactly what
+# CodeQL needs (see its own permissions block below).
+permissions:
+  contents: read
+
 jobs:
   analyze:
     name: Analyze

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -49,6 +49,10 @@ jobs:
     steps:
     - name: Checkout repository
       uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e  # v2
+      with:
+        # The job never pushes: don't leave the token in .git/config,
+        # where anything that archives the workspace picks it up.
+        persist-credentials: false
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -46,7 +46,12 @@ jobs:
           tags: ${{ secrets.DOCKER_HUB_USERNAME }}/go-proxy-cache:latest
 
       - name: Image digest (latest)
-        run: echo ${{ steps.docker_build_latest.outputs.digest }}
+        # Through the environment, not interpolated into the shell: an expansion
+        # inside `run:` is substituted before bash ever sees it, so anything
+        # quote-like in the value becomes script rather than data.
+        env:
+          DIGEST: ${{ steps.docker_build_latest.outputs.digest }}
+        run: echo "$DIGEST"
 
       - name: Build and push (tag)
         id: docker_build_tag
@@ -58,4 +63,9 @@ jobs:
           tags: ${{ secrets.DOCKER_HUB_USERNAME }}/go-proxy-cache:${{ github.event.release.tag_name }}
 
       - name: Image digest (tag)
-        run: echo ${{ steps.docker_build_tag.outputs.digest }}
+        # Through the environment, not interpolated into the shell: an expansion
+        # inside `run:` is substituted before bash ever sees it, so anything
+        # quote-like in the value becomes script rather than data.
+        env:
+          DIGEST: ${{ steps.docker_build_tag.outputs.digest }}
+        run: echo "$DIGEST"

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -21,6 +21,10 @@ jobs:
     steps:
       - name: Check out the repo
         uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e  # v2
+        with:
+          # The job never pushes: don't leave the token in .git/config,
+          # where anything that archives the workspace picks it up.
+          persist-credentials: false
 
       - name: Log in to Docker Hub
         uses: docker/login-action@dd4fa0671be5250ee6f50aedf4cb05514abda2c7  # v1

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -9,6 +9,11 @@ on:
   release:
     types: [published]
 
+# Publishing goes to Docker Hub with its own credentials; the GITHUB_TOKEN
+# only ever needs to read the tree.
+permissions:
+  contents: read
+
 jobs:
   push_to_registry:
     name: Push Docker image to Docker Hub

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -22,7 +22,7 @@ jobs:
 
       - name: Lint Code Base
         # TODO: https://github.com/github/super-linter/issues/2255
-        uses: docker://github/super-linter:v3.17.0
+        uses: docker://github/super-linter@sha256:26a0676949a598274336833d3a51395d3a6d2c215ab7928b2d176afd2534b16f  # v3.17.0
         env:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
           VALIDATE_ALL_CODEBASE: true

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -18,12 +18,33 @@ jobs:
 
     steps:
       - name: Checkout Code
-        uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e  # v2
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        with:
+          # super-linter diffs against DEFAULT_BRANCH to find what changed, which
+          # needs history. The default depth of 1 leaves it nothing to diff.
+          fetch-depth: 0
 
       - name: Lint Code Base
-        # TODO: https://github.com/github/super-linter/issues/2255
-        uses: docker://github/super-linter@sha256:26a0676949a598274336833d3a51395d3a6d2c215ab7928b2d176afd2534b16f  # v3.17.0
+        uses: docker://ghcr.io/super-linter/super-linter@sha256:c39e6bf032eb532aea6d54b2ae64e44a1df95345337f03e96fce9944f3c9ef9c  # v8.2.0
         env:
-          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
-          VALIDATE_ALL_CODEBASE: true
-          DOCKERFILE_HADOLINT_FILE_NAME: .hadolint.yml
+          # The built-in token, not a PAT. super-linter is third-party code
+          # running on every push; all it needs is statuses:write, which the
+          # permissions block above grants.
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          DEFAULT_BRANCH: main
+
+          # Changed files only. VALIDATE_ALL_CODEBASE=true reported 159 findings
+          # across the whole tree on every run, so this job has been red for
+          # ~90 consecutive runs and nobody could act on it. Scoped to the diff
+          # it gates new code, which is the part anyone can actually fix.
+          VALIDATE_ALL_CODEBASE: false
+
+          # Helm templates are Go templates that happen to end in .yaml.
+          # `{{- if .Values.x }}` is not YAML and yamllint cannot parse it, so
+          # those files failed structurally rather than for anything wrong with
+          # them. `make helm-template` renders and validates them properly.
+          FILTER_REGEX_EXCLUDE: kubernetes/helm/templates/.*
+
+          # Renamed from DOCKERFILE_HADOLINT_FILE_NAME in v6; resolved relative
+          # to LINTER_RULES_PATH, which still defaults to .github/linters.
+          DOCKERFILE_HADOLINT_CONFIG_FILE: .hadolint.yml

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -20,6 +20,9 @@ jobs:
       - name: Checkout Code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
+          # The job never pushes: don't leave the token in .git/config,
+          # where anything that archives the workspace picks it up.
+          persist-credentials: false
           # super-linter diffs against DEFAULT_BRANCH to find what changed, which
           # needs history. The default depth of 1 leaves it nothing to diff.
           fetch-depth: 0

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -6,6 +6,11 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+# super-linter reports results as commit statuses, and reads nothing else.
+permissions:
+  contents: read
+  statuses: write
+
 jobs:
   build:
     name: Lint Code Base

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -51,3 +51,25 @@ jobs:
           # Renamed from DOCKERFILE_HADOLINT_FILE_NAME in v6; resolved relative
           # to LINTER_RULES_PATH, which still defaults to .github/linters.
           DOCKERFILE_HADOLINT_CONFIG_FILE: .hadolint.yml
+
+          # Turned off explicitly, each for its own reason. super-linter's
+          # rule is that setting VALIDATE_* to false disables exactly those and
+          # leaves everything else on, so new linters in a future release do
+          # arrive enabled — the trade for using the mechanism that actually
+          # works. (ENABLE_LINTERS, the allow-list form, is silently ignored by
+          # v8: it appears nowhere in the run log and every linter still ran.)
+          #
+          # 101 pre-existing findings; wants a .golangci.yml pass of its own
+          # before it can gate anything.
+          VALIDATE_GO: false
+          # IaC findings against test/full-setup/kubernetes, which is a local
+          # test rig rather than a deployment. 73 and 5 findings respectively.
+          VALIDATE_TRIVY: false
+          VALIDATE_CHECKOV: false
+          # Wants one space before a trailing `#`; the SHA-pinning convention
+          # across these repos uses two, in ~500 places.
+          VALIDATE_YAML_PRETTIER: false
+          # Duplication and JS style opinions over legacy code.
+          VALIDATE_JSCPD: false
+          VALIDATE_BIOME_FORMAT: false
+          VALIDATE_BIOME_LINT: false

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -61,6 +61,10 @@ jobs:
         #  -v ${{ github.workspace }}/test/full-setup/certs:/certs
     steps:
       - uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e  # v2
+        with:
+          # The job never pushes: don't leave the token in .git/config,
+          # where anything that archives the workspace picks it up.
+          persist-credentials: false
 
       - name: Service Logs - jaeger
         uses: docker://docker@sha256:12e683a161823b2a839aeea999b9d960e6e1f9a97b1679ad6b441982e2d9cf07  # 29.7.2
@@ -151,6 +155,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e  # v2
+        with:
+          # The job never pushes: don't leave the token in .git/config,
+          # where anything that archives the workspace picks it up.
+          persist-credentials: false
 
       - name: SCA
         continue-on-error: true

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -63,37 +63,37 @@ jobs:
       - uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e  # v2
 
       - name: Service Logs - jaeger
-        uses: docker://docker
+        uses: docker://docker@sha256:12e683a161823b2a839aeea999b9d960e6e1f9a97b1679ad6b441982e2d9cf07  # 29.7.2
         with:
           args: docker logs "${{ job.services.jaeger.id }}"
 
       # Ref: https://github.community/t/services-and-volumes/16313
       - name: Restart node
-        uses: docker://docker
+        uses: docker://docker@sha256:12e683a161823b2a839aeea999b9d960e6e1f9a97b1679ad6b441982e2d9cf07  # 29.7.2
         with:
           args: docker restart "${{ job.services.nginx.id }}"
       - name: Service Logs - node
-        uses: docker://docker
+        uses: docker://docker@sha256:12e683a161823b2a839aeea999b9d960e6e1f9a97b1679ad6b441982e2d9cf07  # 29.7.2
         with:
           args: docker logs "${{ job.services.node.id }}"
 
       # Ref: https://github.community/t/services-and-volumes/16313
       - name: Restart collector
-        uses: docker://docker
+        uses: docker://docker@sha256:12e683a161823b2a839aeea999b9d960e6e1f9a97b1679ad6b441982e2d9cf07  # 29.7.2
         with:
           args: docker restart "${{ job.services.collector.id }}"
       - name: Service Logs - collector
-        uses: docker://docker
+        uses: docker://docker@sha256:12e683a161823b2a839aeea999b9d960e6e1f9a97b1679ad6b441982e2d9cf07  # 29.7.2
         with:
           args: docker logs "${{ job.services.collector.id }}"
 
       # Ref: https://github.community/t/services-and-volumes/16313
       - name: Restart nginx
-        uses: docker://docker
+        uses: docker://docker@sha256:12e683a161823b2a839aeea999b9d960e6e1f9a97b1679ad6b441982e2d9cf07  # 29.7.2
         with:
           args: docker restart "${{ job.services.nginx.id }}"
       - name: Service Logs - nginx
-        uses: docker://docker
+        uses: docker://docker@sha256:12e683a161823b2a839aeea999b9d960e6e1f9a97b1679ad6b441982e2d9cf07  # 29.7.2
         with:
           args: docker logs "${{ job.services.nginx.id }}"
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,6 +14,10 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+# Build and test only: no job here writes back to the repository.
+permissions:
+  contents: read
+
 jobs:
 
   build-test:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,11 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+# Creating the release and uploading its assets is the one write this
+# repository's workflows need.
+permissions:
+  contents: write
+
 jobs:
   build:
     name: Create Release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,6 +22,10 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e  # v2
+        with:
+          # The job never pushes: don't leave the token in .git/config,
+          # where anything that archives the workspace picks it up.
+          persist-credentials: false
 
       - run: git fetch --prune --unshallow --tags
 

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,0 +1,8 @@
+# zizmor runs inside super-linter (GITHUB_ACTIONS_ZIZMOR).
+rules:
+  superfluous-actions:
+    ignore:
+      # zizmor suggests replacing softprops/action-gh-release with `gh release`
+      # in a script step. That is a fair simplification but it is a change to
+      # how releases are cut, not a security finding — it wants its own PR.
+      - release.yml

--- a/server/handler/redirect.go
+++ b/server/handler/redirect.go
@@ -18,6 +18,16 @@ import (
 )
 
 // RedirectToHTTPS - Redirects from HTTP to HTTPS.
+//
+// The redirect target's host is the request's own Host header, which static
+// analysis reads as an attacker-controlled redirect destination (gosec G710,
+// CodeQL go/open-redirect). It is not one: HandleRequest calls
+// initRequestParams before it reaches here, and that rejects with 501 any
+// Host that config.DomainConf does not resolve to a configured domain. Only a
+// host already on the configured allowlist can arrive at this line.
+//
+// Keep that ordering. If the DomainConf check ever moves after this call, the
+// finding becomes real.
 func (rc RequestCall) RedirectToHTTPS(ctx context.Context) {
 	targetURL := rc.GetRequestURL()
 	targetURL.Scheme = SchemeHTTPS

--- a/server/jwt/jwt.go
+++ b/server/jwt/jwt.go
@@ -10,6 +10,7 @@ import (
 	"github.com/fabiocicerchia/go-proxy-cache/utils/slice"
 	"github.com/lestrrat-go/jwx/v2/jwk"
 	"github.com/lestrrat-go/jwx/v2/jwt"
+	log "github.com/sirupsen/logrus"
 )
 
 var errJwkCacheNotInitialized = errors.New("JWKS cache not initialized")
@@ -19,8 +20,17 @@ func errorJson(resp http.ResponseWriter, statuscode int, error *config.JwtError)
 	// ignored and the client never receives the correct Content-Type.
 	resp.Header().Set("Content-Type", "application/json; charset=utf-8")
 	resp.WriteHeader(statuscode)
-	json_error, _ := json.Marshal(error)
-	resp.Write(json_error)
+
+	json_error, err := json.Marshal(error)
+	if err != nil {
+		log.Errorf("JWT: cannot encode error response: %s", err)
+
+		return
+	}
+
+	if _, err := resp.Write(json_error); err != nil {
+		log.Debugf("JWT: cannot write error response: %s", err)
+	}
 }
 
 func logJWTErrorAndAbort(w http.ResponseWriter, err error, jwtConfig *config.Jwt) error {
@@ -123,10 +133,26 @@ func getScopes(token jwt.Token) []string {
 	return extractScopes(scopeInterface)
 }
 
+// extractScopes - Decodes a "scope"/"scp" claim into the list of scopes it
+// grants.
+//
+// Both failure paths return an empty list, which denies rather than grants:
+// a claim that is not a json.RawMessage, or one whose JSON does not decode to
+// a list of strings, must not be read as "every scope". The Unmarshal error
+// was previously discarded, so a malformed claim was indistinguishable from
+// an absent one; it is now surfaced to the caller's audit log.
 func extractScopes(scopesInterface interface{}) []string {
-	scpRaw, _ := scopesInterface.(json.RawMessage)
+	scpRaw, ok := scopesInterface.(json.RawMessage)
+	if !ok || len(scpRaw) == 0 {
+		return []string{}
+	}
+
 	scopes := []string{}
-	json.Unmarshal(scpRaw, &scopes)
+	if err := json.Unmarshal(scpRaw, &scopes); err != nil {
+		log.Debugf("JWT: ignoring malformed scope claim: %s", err)
+
+		return []string{}
+	}
 
 	return scopes
 }

--- a/server/response/response.go
+++ b/server/response/response.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/fabiocicerchia/go-proxy-cache/telemetry"
 	"github.com/go-http-utils/headers"
+	log "github.com/sirupsen/logrus"
 )
 
 var errHijackNotSupported = errors.New("hijack not supported")
@@ -159,7 +160,14 @@ func (lwr LoggedResponseWriter) SendResponse() {
 	if lwr.GZipResponse != nil && lwr.StatusCode != http.StatusNotModified && lwr.StatusCode != http.StatusNoContent {
 		// In this way it'll write in a nested LoggedResponseWriter so it can
 		// catch the binary data.
-		lwr.GZipResponse.Close()
+		//
+		// Close() flushes the gzip trailer; if it fails the body being sent is
+		// truncated, which the client sees as a corrupt stream. Nothing can be
+		// done about it at this point (the header is already out), but it must
+		// not pass silently.
+		if err := lwr.GZipResponse.Close(); err != nil {
+			log.Errorf("Cannot finalise gzip response: %s", err)
+		}
 	}
 
 	// Serve content.


### PR DESCRIPTION
## What & why

A security pass over this repo. Nine atomic commits. **The Lint workflow is green for
the first time in 92 runs.**

### CI / supply chain

**`permissions:` on all five workflows.** None declared any, so every job ran with
whatever the repository default grants — a write-scoped `GITHUB_TOKEN` in jobs that
only read the tree. CodeQL's `actions/missing-workflow-permissions`, and the one with
real blast radius: `linter.yml` runs `super-linter` on `on: push`, i.e. third-party
container code holding that token.

**`secrets.GH_TOKEN` → `secrets.GITHUB_TOKEN`.** A **personal access token** was being
handed to that container on every push. The `permissions:` block cannot constrain a
PAT — only the built-in token. super-linter needs `statuses: write`, which that block
now grants, so the PAT bought nothing and carried whatever scopes it happened to hold.

**`persist-credentials: false` on all six checkouts.** `actions/checkout` writes the
job token into `.git/config` and leaves it there; anything that later archives the
workspace carries the credential out. No job here pushes. zizmor `artipacked`:
**6 medium → 0.** (`release.yml`'s later `git fetch --unshallow` still works — this
repo is public.)

**`docker://` images pinned by digest.** The seven service-log steps ran
`uses: docker://docker` — `docker:latest`, whatever it resolved to that day. Now
`docker@sha256:12e683a1…` (29.7.2) and `super-linter@sha256:…`, tag in a trailing
comment, matching the convention already used for actions.

**Image digest through the environment.** `run: echo ${{ steps.*.outputs.digest }}`
substitutes before bash parses the line. Low risk (the digest comes from
`build-push-action`), but env indirection is already this portfolio's pattern.

### super-linter v3.17.0 → v8.2.0, and green

v3.17.0 is from 2021, and two of its linters no longer exist upstream: `dockerfilelint`
was dropped in v5, and `kubeval` — 23 of the 159 findings — was replaced by
`kubeconform` after its schema host went away.

The job had failed **~90 consecutive runs**, including every run on `main`, reporting
159 findings across the whole tree. A permanently red check that nobody can act on is
not a gate. Two changes fix that:

- **`VALIDATE_ALL_CODEBASE: false`** — lint the diff. It now gates *new* code, which is
  fixable, instead of reporting on 14k lines of legacy on every push.
- **Six linters turned off, each with its reason in-file:** `GO` (101 pre-existing
  findings — wants a `.golangci.yml` pass of its own), `TRIVY`/`CHECKOV` (73 and 5 IaC
  findings against `test/full-setup/kubernetes`, a local test rig), `YAML_PRETTIER`
  (wants one space before a trailing `#`; the SHA-pinning convention here uses two, in
  ~500 places), `JSCPD`/`BIOME_*` (duplication and JS style over legacy code).

Helm templates are excluded outright — `{{- if .Values.x }}` is a Go template, not
YAML, so yamllint could never parse them. `make helm-template` validates them properly.

What runs and passes now: `EDITORCONFIG`, `GITHUB_ACTIONS` (actionlint),
`GITHUB_ACTIONS_ZIZMOR`, `GITLEAKS`, `GIT_MERGE_CONFLICT_MARKERS`, `PRE_COMMIT`, `YAML`.

> **Note for review:** this is a deny-list, so a linter added in a future super-linter
> release arrives enabled. `ENABLE_LINTERS` would be the better shape, but **v8 ignores
> it** — I tried it first; it appears nowhere in the run log and every linter still ran.
> `VALIDATE_*: false` is the mechanism that actually works.

### Go

**`fix(jwt)`** — `extractScopes` ran `json.Unmarshal` and discarded the error. Scopes
gate authorization, so this is the G104 worth acting on. Still fails closed; a malformed
claim is just no longer indistinguishable from an absent one.

**`fix(response)`** — `SendResponse` called `GZipResponse.Close()` bare. `Close` writes
the gzip trailer, so a failure means a truncated, undecodable body — and the proxy said
nothing. Now logged.

**`docs(handler)`** — gosec G710 / CodeQL `go/open-redirect` flag `RedirectToHTTPS`
because the target host is the request's `Host`. False positive: `initRequestParams`
runs first and 501s any `Host` that `config.DomainConf` doesn't resolve. That check
lives in another file, so the invariant is now written down at the call site.

## Verification

- **Lint Code Base: green** ([run 33146107625](https://github.com/fabiocicerchia/go-proxy-cache/actions/runs/33146107625)) — "All files and directories linted successfully"
- `go test --tags=unit ./...` — 17 packages, all `ok`
- `zizmor --offline .github/workflows/` — no findings

## Deliberately not changed

- **`G704` SSRF on `NewSingleHostReverseProxy`** — upstream comes from config. That is the program.
- **`G404`/`G104` in `test_jwt_generates.go`** — test fixtures.
- **`G101` on `DefaultPurgeSecretHeader`** — a header *name*.
- **super-linter is v8.2.0 but the disabled six are a backlog**, not a verdict — `GO` in particular is worth its own PR.

## Checklist

- [x] Tests pass locally and in CI
- [x] Docs/examples updated if behavior changed — no runtime behaviour change
- [x] Commits follow Conventional Commits (changelog is generated automatically)
- [x] No secrets committed