### PR TITLE
fix(ci): disable GO_MODULES alongside GO in super-linter

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -61,7 +61,16 @@ jobs:
           #
           # 101 pre-existing findings; wants a .golangci.yml pass of its own
           # before it can gate anything.
+          #
+          # GO_MODULES is the same golangci-lint reading the same config, so it
+          # goes with it. It cannot pass as things stand either way:
+          # .github/linters/.golangci.yml is a v1 config — no `version:` key,
+          # and it still disables interfacer/maligned/scopelint, removed from
+          # golangci-lint years ago — while super-linter v8 ships golangci-lint
+          # 2.5.0, which rejects it with "unsupported version of the
+          # configuration" before looking at any Go at all.
           VALIDATE_GO: false
+          VALIDATE_GO_MODULES: false
           # IaC findings against test/full-setup/kubernetes, which is a local
           # test rig rather than a deployment. 73 and 5 findings respectively.
           VALIDATE_TRIVY: false


### PR DESCRIPTION
## What & why

**This is a follow-up to my own mistake in #273.** That PR turned off `VALIDATE_GO`
but left `VALIDATE_GO_MODULES` on, and `Lint Code Base` went red the moment it merged —
after passing on the branch.

The reason is worth recording, because it is a trap in the very config #273 introduced:
`VALIDATE_ALL_CODEBASE: false` lints **the diff**, and that PR changed only workflow
YAML. So the Go linters never ran on the branch and I saw green. The merge commit's diff
includes the three `.go` files, so on `main` they did run.

`GO_MODULES` is the same golangci-lint reading the same config as `GO`, so the reason for
disabling one applies to the other. And it could not have passed regardless of code
quality:

```
Error: can't load config: unsupported version of the configuration: ""
```

`.github/linters/.golangci.yml` is a **v1** config — no `version:` key, and it still
disables `interfacer`, `maligned` and `scopelint`, all removed from golangci-lint years
ago. super-linter v8 ships golangci-lint **2.5.0**, which rejects it with exit 3 before
reading a line of Go.

## The durable fix, deliberately not here

Migrating `.github/linters/.golangci.yml` to v2 format is what actually unblocks Go
linting in this repo — it is the same work the `VALIDATE_GO` comment already defers, and
it will surface the 101 pre-existing findings that motivated the deferral. That wants its
own PR with room to triage them, not a line in this one.

## Verification

`Lint Code Base` on this branch is the check to watch — but note the same trap applies:
this PR's diff is again YAML-only, so the Go linters will be skipped here too and green
proves only that nothing else broke. **The real confirmation is the run on `main` after
merge**, where the Go files are in the diff. I'll watch it.

## Checklist

- [x] Tests pass locally and in CI — see the caveat above; this is a workflow-config change
- [x] Docs/examples updated if behavior changed — the reasoning is in the workflow comment
- [x] Commits follow Conventional Commits (changelog is generated automatically)
- [x] No secrets committed

---
_Generated by [Claude Code](https://claude.ai/code/session_01WyjAX3KfASRg2c1CyjHnza)_