### PR TITLE
fix: say which check turned a request away, instead of "mostly likely"

### DIFF
--- a/server/handler/handler.go
+++ b/server/handler/handler.go
@@ -99,8 +99,40 @@ func initRequestParams(ctx context.Context, res http.ResponseWriter, req *http.R
 
 		logger.LogRequest(rc.Request, rc.Response.StatusCode, rc.Response.Content.Len(), rc.ReqID, cache.StatusMiss)
 
-		return RequestCall{}, fmt.Errorf("Request for %s (listening on :%s) is not allowed (mostly likely it's a configuration mismatch).", rc.Request.Host, listeningPort)
+		return RequestCall{}, fmt.Errorf("Request for %s (listening on :%s) is not allowed: %s", rc.Request.Host, listeningPort, rejectionReason(rc, configFound, listeningPort))
 	}
 
 	return rc, nil
+}
+
+// rejectionReason - Says which of the three checks above turned the request
+// away, in the terms of the config file that decides it.
+//
+// "mostly likely it's a configuration mismatch" was true and unactionable: the
+// two comparisons that produce it were only visible at debug level, so a 501 on
+// every request looked like the proxy refusing to work rather than the proxy
+// saying the Host header and the config disagree.
+func rejectionReason(rc RequestCall, configFound bool, listeningPort string) string {
+	if !configFound {
+		return fmt.Sprintf("no domain in the config matches host %q with scheme %q", rc.GetHostname(), rc.GetScheme())
+	}
+
+	if rc.DomainConfig.Server.Upstream.Host != rc.GetHostname() {
+		return fmt.Sprintf(
+			"request Host %q does not match server.upstream.host %q for this domain -- the two have to be equal; to send that hostname to a different address, keep it as upstream.host and list the address in server.upstream.endpoints",
+			rc.GetHostname(),
+			rc.DomainConfig.Server.Upstream.Host,
+		)
+	}
+
+	if !isLegitPort(rc.DomainConfig.Server.Port, listeningPort) {
+		return fmt.Sprintf(
+			"the port this request arrived on (:%s) is neither server.port.http (%q) nor server.port.https (%q) for this domain",
+			listeningPort,
+			rc.DomainConfig.Server.Port.HTTP,
+			rc.DomainConfig.Server.Port.HTTPS,
+		)
+	}
+
+	return "no reason recorded, which is a bug in this function rather than in the request"
 }

--- a/server/handler/rejection_test.go
+++ b/server/handler/rejection_test.go
@@ -1,0 +1,33 @@
+package handler
+
+import (
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/fabiocicerchia/go-proxy-cache/config"
+)
+
+// TestRejectionReasonNamesTheCheckThatFailed - A 501 has to say which of the
+// three checks turned the request away: "configuration mismatch" was true of
+// all of them and actionable for none.
+func TestRejectionReasonNamesTheCheckThatFailed(t *testing.T) {
+	rc := RequestCall{Request: http.Request{Host: "frankenstein.local"}}
+
+	if got := rejectionReason(rc, false, "80"); !strings.Contains(got, "no domain in the config matches") {
+		t.Errorf("unmatched domain: %q", got)
+	}
+
+	rc.DomainConfig = config.Configuration{}
+	rc.DomainConfig.Server.Upstream.Host = "api"
+	rc.DomainConfig.Server.Port = config.Port{HTTP: "80"}
+	got := rejectionReason(rc, true, "80")
+	if !strings.Contains(got, "server.upstream.host") || !strings.Contains(got, "endpoints") {
+		t.Errorf("host mismatch should name the field and the way out: %q", got)
+	}
+
+	rc.DomainConfig.Server.Upstream.Host = "frankenstein.local"
+	if got := rejectionReason(rc, true, "8082"); !strings.Contains(got, ":8082") {
+		t.Errorf("port mismatch should name the port it arrived on: %q", got)
+	}
+}


### PR DESCRIPTION
Found while diagnosing a 501-on-every-request report against this proxy
(frankenstein `TOOL-ISSUES.md` T14). **The proxy was right and the config was
wrong** — but the message made that impossible to tell from outside:

```
level=error msg="Request for 127.0.0.1:8082 (listening on :80) is not allowed
(mostly likely it's a configuration mismatch)." ReqID=
```

That sentence is true of all three rejection paths in `initRequestParams` and
actionable for none of them, and the two comparisons that decide it
(`hostMatch`, `legitPort`) are logged at **debug** level. From the caller's
side the proxy simply refuses every request.

`rejectionReason` now names the check that failed, in the terms of the config
file that decides it:

- no domain in the config matches host X with scheme Y;
- request `Host` does not equal `server.upstream.host` for the domain — with
  `endpoints` pointed out, since that is the field that lets a hostname be
  served from a different address (this was the actual cause);
- the port it arrived on is neither `server.port.http` nor `.https`.

The status code is unchanged, and the checks themselves are unchanged: matching
`Host` against `upstream.host` is how domains are multiplexed, and a proxy that
matched anything would cache two origins under one key.

One test covers the three branches. `go build ./...` and `go test ./server/...
./config/...` pass.
