### PR TITLE
fix: health-check the upstream over the upstream's own scheme

### DIFF
--- a/config/model.go
+++ b/config/model.go
@@ -61,7 +61,7 @@ type Configuration struct {
 	Log            Log                           `yaml:"log"`
 	Tracing        Tracing                       `yaml:"tracing"`
 	domainsCache   map[string]Configuration
-	Jwt		   	   Jwt					 		 `yaml:"jwt"`
+	Jwt            Jwt `yaml:"jwt"`
 }
 
 // Domains - Overrides per domain.
@@ -169,12 +169,16 @@ func (u Upstream) GetDomainID() string {
 
 // HealthCheck - Defines the health check settings.
 type HealthCheck struct {
-	StatusCodes   []string      `yaml:"status_codes" envconfig:"HEALTHCHECK_STATUS_CODES" split_words:"true"`
-	Timeout       time.Duration `yaml:"timeout" envconfig:"HEALTHCHECK_TIMEOUT"`
-	Interval      time.Duration `yaml:"interval" envconfig:"HEALTHCHECK_INTERVAL"`
-	Port          string        `yaml:"port" envconfig:"HEALTHCHECK_PORT" default:"443"`
-	Scheme        string        `yaml:"scheme" envconfig:"HEALTHCHECK_SCHEME" default:"https"`
-	AllowInsecure bool          `yaml:"allow_insecure" envconfig:"HEALTHCHECK_ALLOW_INSECURE"`
+	StatusCodes []string      `yaml:"status_codes" envconfig:"HEALTHCHECK_STATUS_CODES" split_words:"true"`
+	Timeout     time.Duration `yaml:"timeout" envconfig:"HEALTHCHECK_TIMEOUT"`
+	Interval    time.Duration `yaml:"interval" envconfig:"HEALTHCHECK_INTERVAL"`
+	// No defaults on these two: unset has to stay representable, so the
+	// balancer can inherit the upstream's scheme and port. Defaulting them to
+	// https/443 here probed a plain-HTTP upstream over TLS and failed every
+	// check with "server gave HTTP response to HTTPS client".
+	Port          string `yaml:"port" envconfig:"HEALTHCHECK_PORT"`
+	Scheme        string `yaml:"scheme" envconfig:"HEALTHCHECK_SCHEME"`
+	AllowInsecure bool   `yaml:"allow_insecure" envconfig:"HEALTHCHECK_ALLOW_INSECURE"`
 }
 
 // Timeout - Defines the server timeouts.
@@ -257,10 +261,10 @@ type DomainSet struct {
 
 // Jwt - Defines the config for the jwt validation.
 type Jwt struct {
-	ExcludedPaths       []string   `yaml:"excluded_paths" envconfig:"JWT_EXCLUDED_PATHS" split_words:"true"`
-	AllowedScopes       []string   `yaml:"allowed_scopes" envconfig:"JWT_ALLOWED_SCOPES" split_words:"true"`
-	JwksUrl             string     `yaml:"jwks_url" envconfig:"JWT_JWKS_URL"`
-	JwksRefreshInterval int        `yaml:"jwks_refresh_interval" envconfig:"JWT_REFRESH_INTERVAL" default:"15"`
+	ExcludedPaths       []string `yaml:"excluded_paths" envconfig:"JWT_EXCLUDED_PATHS" split_words:"true"`
+	AllowedScopes       []string `yaml:"allowed_scopes" envconfig:"JWT_ALLOWED_SCOPES" split_words:"true"`
+	JwksUrl             string   `yaml:"jwks_url" envconfig:"JWT_JWKS_URL"`
+	JwksRefreshInterval int      `yaml:"jwks_refresh_interval" envconfig:"JWT_REFRESH_INTERVAL" default:"15"`
 	JwkCache            *jwk.Cache
 	Context             context.Context
 	Logger              *logrus.Logger

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -247,12 +247,15 @@ server:
       timeout: ~
       # Interval frequency for health checks.
       interval: ~
-      # Port to be used for requests forwarding.
-      # Default: incoming connection.
-      # Values: 80, 443.
-      port: 443
-      # Fallback scheme if endpoint doesn't provide it.
-      scheme: https
+      # Port to probe on.
+      # Default: the upstream's port; 80/443 by scheme when it has none.
+      port: ~
+      # Fallback scheme if the endpoint doesn't provide one.
+      # Default: the upstream's scheme. Setting this to https for an upstream
+      # served over http fails every check with "server gave HTTP response to
+      # HTTPS client" — the health check goes to the same place the traffic
+      # does, unless you say otherwise here.
+      scheme: ~
       # Allow healthchecks on self-signed TLS certificates (or expired/invalid).
       # Default: false
       allow_insecure: false

--- a/docs/REAL-CASE.md
+++ b/docs/REAL-CASE.md
@@ -236,12 +236,15 @@ server:
       timeout: ~
       # Interval frequency for health checks.
       interval: ~
-      # Port to be used for requests forwarding.
-      # Default: incoming connection.
-      # Values: 80, 443.
-      port: 443
-      # Fallback scheme if endpoint doesn't provide it.
-      scheme: https
+      # Port to probe on.
+      # Default: the upstream's port; 80/443 by scheme when it has none.
+      port: ~
+      # Fallback scheme if the endpoint doesn't provide one.
+      # Default: the upstream's scheme. Setting this to https for an upstream
+      # served over http fails every check with "server gave HTTP response to
+      # HTTPS client" — the health check goes to the same place the traffic
+      # does, unless you say otherwise here.
+      scheme: ~
       # Allow healthchecks on self-signed TLS certificates (or expired/invalid).
       # Default: false
       allow_insecure: false

--- a/server/balancer/balancer.go
+++ b/server/balancer/balancer.go
@@ -74,8 +74,52 @@ func initBalancer(name string, config config.Upstream, enableHealthchecks bool, 
 	lb[name] = b
 
 	if enableHealthchecks {
-		CheckHealth(b.GetNodeBalancer(), config.Host, config.HealthCheck)
+		CheckHealth(b.GetNodeBalancer(), config.Host, healthCheckFor(config))
 	}
+}
+
+// healthCheckFor - The upstream's health-check settings, with the scheme and
+// port inherited from the upstream when the check does not set its own.
+//
+// They used to default to https/443 independently of the upstream, so an
+// upstream declared `scheme: http` was probed over TLS and every check failed
+// with `server gave HTTP response to HTTPS client` — an error that reads like
+// the upstream misbehaving rather than the prober asking wrongly. A health
+// check is a request to the same place the traffic goes; anything else is a
+// check of something you are not serving.
+// The two schemes this proxy speaks. Local to the package: server/handler
+// exports the same pair and imports this one, so borrowing them would be a
+// cycle.
+const (
+	schemeHTTP  = "http"
+	schemeHTTPS = "https"
+)
+
+func healthCheckFor(upstream config.Upstream) config.HealthCheck {
+	hc := upstream.HealthCheck
+
+	hc.Scheme = firstNonEmpty(hc.Scheme, upstream.Scheme, schemeHTTPS)
+	hc.Port = firstNonEmpty(hc.Port, upstream.Port, defaultHealthCheckPort(hc.Scheme))
+
+	return hc
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, v := range values {
+		if v != "" {
+			return v
+		}
+	}
+
+	return ""
+}
+
+func defaultHealthCheckPort(scheme string) string {
+	if scheme == schemeHTTP {
+		return "80"
+	}
+
+	return "443"
 }
 
 // InitRoundRobin - Initialise the LB algorithm for round robin selection.

--- a/server/balancer/healthcheck_scheme_test.go
+++ b/server/balancer/healthcheck_scheme_test.go
@@ -1,0 +1,36 @@
+package balancer
+
+import (
+	"testing"
+
+	"github.com/fabiocicerchia/go-proxy-cache/config"
+)
+
+// TestHealthCheckInheritsTheUpstreamScheme - A health check probes the place
+// the traffic goes. Defaulting it to https/443 independently of the upstream
+// probed a plain-HTTP origin over TLS, and every check failed with "server
+// gave HTTP response to HTTPS client".
+func TestHealthCheckInheritsTheUpstreamScheme(t *testing.T) {
+	http := config.Upstream{Scheme: "http", Port: "8080"}
+	if hc := healthCheckFor(http); hc.Scheme != "http" || hc.Port != "8080" {
+		t.Errorf("plain http upstream: got %s://:%s, want http://:8080", hc.Scheme, hc.Port)
+	}
+
+	// An explicit health-check setting still wins over the upstream.
+	explicit := config.Upstream{Scheme: "http", Port: "8080"}
+	explicit.HealthCheck = config.HealthCheck{Scheme: "https", Port: "8443"}
+	if hc := healthCheckFor(explicit); hc.Scheme != "https" || hc.Port != "8443" {
+		t.Errorf("explicit override: got %s://:%s, want https://:8443", hc.Scheme, hc.Port)
+	}
+
+	// Nothing declared anywhere keeps the old default.
+	if hc := healthCheckFor(config.Upstream{}); hc.Scheme != "https" || hc.Port != "443" {
+		t.Errorf("empty upstream: got %s://:%s, want https://:443", hc.Scheme, hc.Port)
+	}
+
+	// An https upstream on a non-standard port is probed there, not on 443.
+	tls := config.Upstream{Scheme: "https", Port: "9443"}
+	if hc := healthCheckFor(tls); hc.Port != "9443" {
+		t.Errorf("https upstream port: got %s, want 9443", hc.Port)
+	}
+}


### PR DESCRIPTION
Found while diagnosing why a plain-HTTP upstream's health checks all failed:

```
Healthcheck failed for https://api:8080: server gave HTTP response to HTTPS client
```

The upstream declares `scheme: http` in both the global and the domain block.
The health check goes over **https** anyway, because `health_check.scheme`
carries `default:"https"` and `health_check.port` `default:"443"` — defaults
that are independent of the upstream they belong to. Nothing in the config
hints that a second scheme has to be set to match the first, and the error
reads as the upstream misbehaving rather than the prober asking wrongly.

Both now inherit from the upstream when the health check does not set its own:

| config | before | after |
|---|---|---|
| `scheme: http`, `port: 8080` | `https://api:8080` | `http://api:8080` |
| `scheme: https`, `port: 9443` | `https://api:443` | `https://api:9443` |
| explicit `health_check.scheme` | as set | as set (unchanged) |
| nothing declared anywhere | `https://…:443` | `https://…:443` (unchanged) |

The `default:` struct tags had to go for "unset" to be representable at all —
envconfig fills them in before the balancer ever sees the value.

One test covers the four rows. `go build ./...` and the `server/...` +
`config/...` packages pass.
