### PR TITLE
fix: store responses that have no Vary header

### DIFF
--- a/cache/engine/client/client.go
+++ b/cache/engine/client/client.go
@@ -252,7 +252,25 @@ func (rdb *RedisClient) List(key string) ([]string, error) {
 }
 
 // Push - Append values to a list.
+//
+// Pushing nothing is a no-op, not an error: `RPUSH key` with no members is
+// rejected by Redis with "wrong number of arguments", and go-redis flattens an
+// empty slice into exactly that call. The caller's intent — a list with no
+// entries — is a key that does not exist, which is what every reader here
+// already treats as empty.
+//
+// This is not hypothetical. StoreMetadata pushes the response's Vary header
+// list, and a response without a Vary header yields an empty one, so every
+// such response failed to store with
+//
+//	Not Stored: ERR wrong number of arguments for 'rpush' command
+//
+// i.e. the cache stored nothing at all for the ordinary case.
 func (rdb *RedisClient) Push(ctx context.Context, key string, values []string) error {
+	if len(values) == 0 {
+		return nil
+	}
+
 	_, err := circuitbreaker.CB(rdb.Name, rdb.logger).Execute(rdb.doPushKey(ctx, key, values))
 
 	return err

--- a/cache/engine/client/client_test.go
+++ b/cache/engine/client/client_test.go
@@ -266,6 +266,40 @@ func TestPushList(t *testing.T) {
 	assert.Nil(t, err)
 }
 
+// TestPushListEmptyIsANoOp - A response without a Vary header stores an empty
+// metadata list. `RPUSH key` with no members is an error in Redis, so this used
+// to abort the whole store with "Not Stored: ERR wrong number of arguments for
+// 'rpush' command" — i.e. nothing was cached for the ordinary case.
+func TestPushListEmptyIsANoOp(t *testing.T) {
+	initLogs()
+
+	cfg := config.Configuration{
+		Cache: config.Cache{
+			Hosts: []string{utils.GetEnv("REDIS_HOSTS", "localhost:6379")},
+			DB:    0,
+		},
+		CircuitBreaker: circuit_breaker.CircuitBreaker{
+			Threshold:   2,
+			FailureRate: 0.5,
+			Interval:    0,
+			Timeout:     time.Duration(1),
+		},
+	}
+
+	circuit_breaker.InitCircuitBreaker(redisConnName, cfg.CircuitBreaker, logger.GetGlobal())
+
+	rdb := client.Connect(redisConnName, cfg.Cache, log.StandardLogger())
+
+	err := rdb.Push(context.Background(), "empty_list", []string{})
+	assert.Nil(t, err)
+
+	// A list with no entries is a key that does not exist, which every reader
+	// here already treats as empty.
+	value, err := rdb.List("empty_list")
+	assert.Nil(t, err)
+	assert.Empty(t, value)
+}
+
 func TestDelWildcardNoMatch(t *testing.T) {
 	initLogs()
 


### PR DESCRIPTION
**The cache stores nothing.** Not "sometimes", not "for some responses" —
every response without a `Vary` header fails to store, and almost no response
has one:

```
HTTP/1.1 GET / - Not Stored: ERR wrong number of arguments for 'rpush' command
```

From outside that looks like `X-Go-Proxy-Cache-Status: MISS` on every request
and `redis-cli DBSIZE` = 0, forever, with a proxy that otherwise works fine —
it forwards, it answers 200, it just never caches.

The chain:

1. `GetVary` returns an **empty slice** when the response has no `Vary` header
   (correctly — `strings.Split("", ",")` returning `[""]` was the older bug).
2. `StoreMetadata` pushes that list.
3. go-redis flattens an empty slice into `RPUSH key` with no members.
4. Redis rejects it, and the store aborts on the error before writing anything
   else.

Pushing nothing is now a no-op in `Push`: a list with no entries is a key that
does not exist, which is what every reader in this package already treats as
empty. The guard is in `Push` rather than at the call site because any caller
with an empty list hits the same wall.

Verified end to end against a real stack — same commit, same config, only this
patch differing:

| | before | after |
|---|---|---|
| three GETs | MISS, MISS, MISS | MISS, **HIT**, **HIT** |
| `redis-cli DBSIZE` | 0 | 2 |
| log | `Not Stored: ERR wrong number of arguments` | *(nothing)* |

One functional test covers it, alongside the existing `TestPushList`.
