### PR TITLE
fix(publish): publish to GHCR, on demand, signed, from one build

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,71 +1,133 @@
-# This workflow uses actions that are not certified by GitHub.
-# They are provided by a third-party and are governed by
-# separate terms of service, privacy policy, and support
-# documentation.
-
 name: Publish Docker image
+
+# The image nobody could get. This workflow only ever ran on `release:
+# published`, the last release was v1.2.0 in 2021, and there was no manual
+# trigger — so `fabiocicerchia/go-proxy-cache:latest` on Docker Hub is a 2021
+# build and every fix merged since has been invisible to anyone running the
+# image rather than the source.
+#
+# Three things change that:
+#
+#   * GHCR, authenticated with the token every workflow already carries, so
+#     publishing no longer depends on a Docker Hub credential being present.
+#     Docker Hub stays as a mirror when the credential is there.
+#   * workflow_dispatch, so a publish can be run by hand — and `push: tags`,
+#     because a release created with GITHUB_TOKEN does not start workflows,
+#     which is the other half of why this never fired.
+#   * one build, many tags. `latest` and the version tag used to be two
+#     separate builds, so they were two different digests of the same commit;
+#     a signature or an SBOM for one said nothing about the other.
 
 on:
   release:
     types: [published]
+  push:
+    tags: ["v*"]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: Version tag to publish (defaults to the current ref).
+        required: false
+        type: string
 
-# Publishing goes to Docker Hub with its own credentials; the GITHUB_TOKEN
-# only ever needs to read the tree.
 permissions:
   contents: read
 
+env:
+  IMAGE: ghcr.io/${{ github.repository }}
+  DOCKERHUB_IMAGE: docker.io/${{ github.repository }}
+
 jobs:
   push_to_registry:
-    name: Push Docker image to Docker Hub
+    name: Push Docker image
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write # push to ghcr.io
+      id-token: write # keyless cosign signing via OIDC
     steps:
       - name: Check out the repo
-        uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e  # v2
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
-          # The job never pushes: don't leave the token in .git/config,
+          # The job never pushes to git: don't leave the token in .git/config,
           # where anything that archives the workspace picks it up.
           persist-credentials: false
 
+      - name: Work out the version tag
+        id: version
+        env:
+          # Through the environment, never interpolated into the shell: an
+          # expansion inside `run:` is substituted before bash sees it, so
+          # anything quote-like in a release name becomes script rather than
+          # data.
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+          INPUT_TAG: ${{ inputs.tag }}
+          REF_NAME: ${{ github.ref_name }}
+        run: |
+          VERSION="${RELEASE_TAG:-${INPUT_TAG:-$REF_NAME}}"
+          case "$VERSION" in
+            v*) ;;
+            *)  echo "::error::refusing to publish '$VERSION': expected a vX.Y.Z tag"; exit 1 ;;
+          esac
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "publishing $VERSION"
+
+      - name: Log in to GHCR
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f  # v4.6.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # Conditional on the credential existing, so a fork — or this repo before
+      # anyone sets it — still publishes to GHCR instead of failing here.
       - name: Log in to Docker Hub
-        uses: docker/login-action@dd4fa0671be5250ee6f50aedf4cb05514abda2c7  # v1
+        id: dockerhub
+        if: ${{ env.DOCKER_HUB_USERNAME != '' }}
+        env:
+          DOCKER_HUB_USERNAME: ${{ secrets.DOCKER_HUB_USERNAME }}
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f  # v4.6.0
         with:
           username: ${{ secrets.DOCKER_HUB_USERNAME }}
           password: ${{ secrets.DOCKER_HUB_TOKEN }}
 
       - name: Set up Docker Buildx
-        id: buildx
-        uses: docker/setup-buildx-action@f211e3e9ded2d9377c8cadc4489a4e38014bc4c9  # v1
+        uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e  # v4.3.0
 
-      - name: Build and push (latest)
-        id: docker_build_latest
-        uses: docker/build-push-action@ac9327eae2b366085ac7f6a2d02df8aa8ead720a  # v2
+      - name: Compute tags
+        id: tags
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+          DOCKERHUB: ${{ steps.dockerhub.outcome == 'success' }}
+        run: |
+          TAGS="$IMAGE:$VERSION,$IMAGE:latest"
+          if [ "$DOCKERHUB" = "true" ]; then
+            TAGS="$TAGS,$DOCKERHUB_IMAGE:$VERSION,$DOCKERHUB_IMAGE:latest"
+          fi
+          echo "tags=$TAGS" >> "$GITHUB_OUTPUT"
+
+      - name: Build and push
+        id: build
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a  # v7.3.0
         with:
           context: ./
           file: ./docker/Dockerfile
           push: true
-          tags: ${{ secrets.DOCKER_HUB_USERNAME }}/go-proxy-cache:latest
+          tags: ${{ steps.tags.outputs.tags }}
 
-      - name: Image digest (latest)
-        # Through the environment, not interpolated into the shell: an expansion
-        # inside `run:` is substituted before bash ever sees it, so anything
-        # quote-like in the value becomes script rather than data.
+      - uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6  # v4.1.2
+
+      # By digest, never by tag: a tag is mutable, so a signature attached to
+      # one says nothing about the bytes a later puller receives. Every tag in
+      # this push shares the digest — but only within one registry, so each
+      # registry the image lands in needs its own signature.
+      - name: Sign the pushed digest
         env:
-          DIGEST: ${{ steps.docker_build_latest.outputs.digest }}
-        run: echo "$DIGEST"
-
-      - name: Build and push (tag)
-        id: docker_build_tag
-        uses: docker/build-push-action@ac9327eae2b366085ac7f6a2d02df8aa8ead720a  # v2
-        with:
-          context: ./
-          file: ./docker/Dockerfile
-          push: true
-          tags: ${{ secrets.DOCKER_HUB_USERNAME }}/go-proxy-cache:${{ github.event.release.tag_name }}
-
-      - name: Image digest (tag)
-        # Through the environment, not interpolated into the shell: an expansion
-        # inside `run:` is substituted before bash ever sees it, so anything
-        # quote-like in the value becomes script rather than data.
-        env:
-          DIGEST: ${{ steps.docker_build_tag.outputs.digest }}
-        run: echo "$DIGEST"
+          DIGEST: ${{ steps.build.outputs.digest }}
+          DOCKERHUB: ${{ steps.dockerhub.outcome == 'success' }}
+        run: |
+          cosign sign --yes "${IMAGE}@${DIGEST}"
+          if [ "$DOCKERHUB" = "true" ]; then
+            cosign sign --yes "${DOCKERHUB_IMAGE}@${DIGEST}"
+          fi
+          echo "published ${IMAGE}@${DIGEST}" >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
`fabiocicerchia/go-proxy-cache:latest` on Docker Hub was built **2021-09-20**.

```
latest    2021-09-20T21:16:09
v1.2.0    2021-09-20T21:16:11
v1.1.0    2021-08-30T07:11:03
```

This workflow only ever ran on `release: published`; the last release was
v1.2.0 in September 2021; and there was no `workflow_dispatch`, so it could not
even be run by hand. There is no GHCR copy. Every fix merged in the five years
since has been invisible to anyone who runs the image rather than the source —
including the two open beside this one, and including whatever this repo does
next.

Four changes:

- **GHCR**, authenticated with the token every workflow already carries, so
  publishing no longer waits on a Docker Hub credential being configured.
  Docker Hub stays as a mirror when the credential is there, and is skipped
  cleanly when it is not (a fork gets the GHCR half rather than a failure).
- **`workflow_dispatch`** with an optional tag, plus **`push: tags: ["v*"]`** —
  a release created with GITHUB_TOKEN does not start workflows, which is the
  other half of why this never fired.
- **One build, many tags.** `latest` and the version tag were two separate
  `build-push-action` invocations, so they were two different digests of the
  same commit: a signature, an SBOM or a scan for one said nothing about the
  other.
- **cosign**, keyless, on each pushed digest, per registry — signatures live
  beside the image they sign, so one per registry.

Also: the image name no longer comes from `secrets.DOCKER_HUB_USERNAME` (a
secret that was never secret — it is in every published tag), and the action
pins are current instead of v1/v2-era.

The version tag is validated before anything is pushed, so a dispatch with a
typo fails at the first step instead of publishing `:main` or `:`.

Verified locally: `docker build -f docker/Dockerfile` succeeds, the resulting
image starts and proxies, and the workflow parses with every `uses:` pinned to
a full SHA.
